### PR TITLE
챌린지 그만두기 확인 바텀 시트 구현

### DIFF
--- a/data/src/main/java/com/whyranoid/data/datasource/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/ChallengeDataSourceImpl.kt
@@ -4,24 +4,20 @@ import com.whyranoid.domain.datasource.ChallengeDataSource
 import com.whyranoid.domain.model.challenge.Challenge
 import com.whyranoid.domain.model.challenge.ChallengePreview
 import com.whyranoid.domain.model.challenge.ChallengeType
-import kotlinx.coroutines.delay
 
 class ChallengeDataSourceImpl : ChallengeDataSource {
     // TODO: change to api call
     override suspend fun getNewChallengePreviews(): List<ChallengePreview> {
-        delay(1500)
         return List(10) { ChallengePreview.DUMMY }
     }
 
     // TODO: change to api call
     override suspend fun getChallengingPreviews(): List<ChallengePreview> {
-        delay(500)
         return List(10) { ChallengePreview.DUMMY }
     }
 
     // TODO: change to api call
     override suspend fun getChallengeDetail(challengeId: Long): Challenge {
-        delay(1000)
         return Challenge.DUMMY.copy(
             id = challengeId
         )

--- a/domain/src/main/java/com/whyranoid/domain/model/challenge/Challenge.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/challenge/Challenge.kt
@@ -26,7 +26,7 @@ data class Challenge(
             challengeType = ChallengeType.values().toList().shuffled().first(),
             badge = Badge(
                 id = 1,
-                name = "뱃지 이름",
+                name = "햄버거",
                 imageUrl = "https://picsum.photos/250/250",
             ),
 

--- a/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
@@ -1,0 +1,121 @@
+package com.whyranoid.presentation.component.bottomsheet
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.whyranoid.domain.model.challenge.Challenge
+import com.whyranoid.presentation.component.button.WalkieNegativeButton
+import com.whyranoid.presentation.component.button.WalkiePositiveButton
+import com.whyranoid.presentation.theme.SystemColor
+import com.whyranoid.presentation.theme.WalkieTypography
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun ChallengeExitModalBottomSheetContainer(
+    challenge: Challenge,
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    modalSheetState: ModalBottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmStateChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = true
+    ),
+    onPositiveButtonClicked: (Challenge) -> Unit = {},
+    onNegativeButtonClicked: (Challenge) -> Unit = {},
+    content: @Composable () -> Unit = {
+
+    }
+) {
+    ModalBottomSheetLayout(
+        sheetState = modalSheetState,
+        sheetShape = RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp),
+        sheetContent = {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+
+                Spacer(modifier = Modifier.height(40.dp))
+
+                Text(
+                    text = "정말 도전을 멈추시겠어요?",
+                    style = WalkieTypography.Title
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "${challenge.badge.name} 뱃지가 코 앞이에요.",
+                    style = WalkieTypography.Body2.copy(color = SystemColor.Negative)
+                )
+
+                Spacer(modifier = Modifier.height(22.dp))
+
+                Text(
+                    text = challenge.title,
+                    style = WalkieTypography.SubTitle.copy(color = SystemColor.Negative)
+                )
+
+                Spacer(modifier = Modifier.height(22.dp))
+
+                AsyncImage(
+                    model = challenge.badge.imageUrl, contentDescription = "",
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(CircleShape)
+                        .padding(bottom = 10.dp),
+                    contentScale = ContentScale.Crop
+                )
+
+                Text(
+                    text = "진행률 ${challenge.process}%",
+                    style = WalkieTypography.Body2.copy(
+                        color = SystemColor.Negative,
+                        fontWeight = FontWeight(700)
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(37.dp))
+
+                WalkiePositiveButton(text = "계속하기") {
+                    onPositiveButtonClicked(challenge)
+                    coroutineScope.launch {
+                        modalSheetState.hide()
+                    }
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+                WalkieNegativeButton(text = "그만하기") {
+                    onNegativeButtonClicked(challenge)
+                    coroutineScope.launch {
+                        modalSheetState.hide()
+                    }
+                }
+                Spacer(modifier = Modifier.height(19.dp))
+            }
+        }
+    ) {
+        content()
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -80,7 +80,8 @@ fun AppScreen() {
             composable(Screen.ChallengeDetailScreen.route, Screen.ChallengeDetailScreen.arguments) { backStackEntry ->
                 val arguments = requireNotNull(backStackEntry.arguments)
                 val challengeId = arguments.getLong("challengeId")
-                ChallengeDetailScreen(navController, challengeId)
+                val isChallenging = arguments.getBoolean("isChallenging")
+                ChallengeDetailScreen(navController, challengeId, isChallenging)
             }
 
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
@@ -27,9 +27,10 @@ sealed class Screen(
     object MyPage : Screen("myPage", R.string.my_page, Icons.Rounded.Person)
 
     object ChallengeDetailScreen : Screen(
-        route = "challengeDetail/{challengeId}",
+        route = "challengeDetail/{challengeId}/{isChallenging}",
         arguments = listOf(
-            navArgument("challengeId") { type = NavType.LongType }
+            navArgument("challengeId") { type = NavType.LongType },
+            navArgument("isChallenging") { type = NavType.BoolType },
         ))
 
     companion object {

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.presentation.screens.challenge
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
@@ -33,6 +35,8 @@ import com.whyranoid.presentation.component.ChallengeGoalContent
 import com.whyranoid.presentation.component.UserIcon
 import com.whyranoid.presentation.component.button.WalkiePositiveButton
 import com.whyranoid.presentation.reusable.WalkieCircularProgressIndicator
+import com.whyranoid.presentation.theme.SystemColor
+import com.whyranoid.presentation.theme.WalkieTypography
 import com.whyranoid.presentation.viewmodel.ChallengeDetailState
 import com.whyranoid.presentation.viewmodel.ChallengeDetailViewModel
 import org.koin.androidx.compose.koinViewModel
@@ -41,7 +45,8 @@ import org.orbitmvi.orbit.compose.collectAsState
 @Composable
 fun ChallengeDetailScreen(
     navController: NavController,
-    challengeId: Long
+    challengeId: Long,
+    isChallenging: Boolean
 ) {
 
     val viewModel = koinViewModel<ChallengeDetailViewModel>()
@@ -52,12 +57,13 @@ fun ChallengeDetailScreen(
 
     val state by viewModel.collectAsState()
 
-    ChallengeDetailContent(state)
+    ChallengeDetailContent(state, isChallenging)
 }
 
 @Composable
 fun ChallengeDetailContent(
     state: ChallengeDetailState,
+    isChallenging: Boolean
 ) {
 
     Scaffold() { paddingValues ->
@@ -170,9 +176,27 @@ fun ChallengeDetailContent(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(28.dp))
+                    if (isChallenging) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Spacer(modifier = Modifier.height(130.dp))
+                            Text(
+                                modifier = Modifier.clickable {
 
-                    WalkiePositiveButton(text = "도전하기")
+                                },
+                                text = "그만할래요",
+                                style = WalkieTypography.Body1.copy(SystemColor.Negative),
+                                textDecoration = TextDecoration.Underline
+                            )
+                            Spacer(modifier = Modifier.height(40.dp))
+                        }
+                    } else {
+                        Spacer(modifier = Modifier.height(28.dp))
+                        WalkiePositiveButton(text = "도전하기")
+                    }
 
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
@@ -14,11 +14,15 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,15 +34,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.whyranoid.domain.model.challenge.Challenge
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.component.ChallengeGoalContent
 import com.whyranoid.presentation.component.UserIcon
+import com.whyranoid.presentation.component.bottomsheet.ChallengeExitModalBottomSheetContainer
 import com.whyranoid.presentation.component.button.WalkiePositiveButton
 import com.whyranoid.presentation.reusable.WalkieCircularProgressIndicator
 import com.whyranoid.presentation.theme.SystemColor
 import com.whyranoid.presentation.theme.WalkieTypography
 import com.whyranoid.presentation.viewmodel.ChallengeDetailState
 import com.whyranoid.presentation.viewmodel.ChallengeDetailViewModel
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 
@@ -60,148 +67,166 @@ fun ChallengeDetailScreen(
     ChallengeDetailContent(state, isChallenging)
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ChallengeDetailContent(
     state: ChallengeDetailState,
     isChallenging: Boolean
 ) {
 
-    Scaffold() { paddingValues ->
+    val challenge = Challenge.DUMMY
 
-        val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    val modalSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmStateChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = true
+    )
 
-        state.challenge.getDataOrNull()?.let { challenge ->
+    ChallengeExitModalBottomSheetContainer(
+        challenge = challenge,
+        coroutineScope = coroutineScope,
+        modalSheetState = modalSheetState
+    ) {
+        Scaffold() { paddingValues ->
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .verticalScroll(scrollState),
-            ) {
-                // TODO: Async Image
-                Image(
-                    painter = painterResource(id = R.drawable.dummy_challenge_banner),
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxWidth(),
-                    contentScale = ContentScale.FillWidth
-                )
+            val scrollState = rememberScrollState()
+
+            state.challenge.getDataOrNull()?.let { challenge ->
 
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(20.dp),
+                        .padding(paddingValues)
+                        .verticalScroll(scrollState),
                 ) {
-
-                    Text(
-                        text = challenge.title,
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight(700),
+                    // TODO: Async Image
+                    Image(
+                        painter = painterResource(id = R.drawable.dummy_challenge_banner),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxWidth(),
+                        contentScale = ContentScale.FillWidth
                     )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    Text(
-                        text = challenge.contents,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight(500),
-                    )
-
-                    Spacer(modifier = Modifier.height(40.dp))
-
-                    Text(
-                        text = "도전 내용",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight(700),
-                    )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    ChallengeGoalContent(challenge)
-
-                    Spacer(modifier = Modifier.height(42.dp))
-
-                    Text(
-                        text = "성공 시 달성 뱃지",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight(700),
-                    )
-
-                    Spacer(modifier = Modifier.height(10.dp))
 
                     Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(20.dp),
                     ) {
-                        AsyncImage(
-                            model = challenge.badge.imageUrl, contentDescription = "",
-                            modifier = Modifier
-                                .size(100.dp)
-                                .clip(CircleShape),
-                            contentScale = ContentScale.Crop
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
 
                         Text(
-                            text = challenge.badge.name,
+                            text = challenge.title,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight(700),
+                        )
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        Text(
+                            text = challenge.contents,
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight(500),
+                        )
+
+                        Spacer(modifier = Modifier.height(40.dp))
+
+                        Text(
+                            text = "도전 내용",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight(700),
+                        )
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        ChallengeGoalContent(challenge)
+
+                        Spacer(modifier = Modifier.height(42.dp))
+
+                        Text(
+                            text = "성공 시 달성 뱃지",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight(700),
+                        )
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            AsyncImage(
+                                model = challenge.badge.imageUrl, contentDescription = "",
+                                modifier = Modifier
+                                    .size(100.dp)
+                                    .clip(CircleShape),
+                                contentScale = ContentScale.Crop
+                            )
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            Text(
+                                text = challenge.badge.name,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight(500),
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(40.dp))
+
+                        Text(
+                            text = "함께 도전하는 워키들",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight(700),
+                        )
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        Text(
+                            text = "${challenge.participantCount}명",
                             fontSize = 12.sp,
                             fontWeight = FontWeight(500),
                         )
-                    }
 
-                    Spacer(modifier = Modifier.height(40.dp))
+                        Spacer(modifier = Modifier.height(10.dp))
 
-                    Text(
-                        text = "함께 도전하는 워키들",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight(700),
-                    )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    Text(
-                        text = "${challenge.participantCount}명",
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight(500),
-                    )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    LazyRow {
-                        challenge.participants.forEach { participant ->
-                            item {
-                                UserIcon(user = participant)
-                                Spacer(modifier = Modifier.width(8.dp))
+                        LazyRow {
+                            challenge.participants.forEach { participant ->
+                                item {
+                                    UserIcon(user = participant)
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                }
                             }
                         }
-                    }
 
-                    if (isChallenging) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Spacer(modifier = Modifier.height(130.dp))
-                            Text(
-                                modifier = Modifier.clickable {
-
-                                },
-                                text = "그만할래요",
-                                style = WalkieTypography.Body1.copy(SystemColor.Negative),
-                                textDecoration = TextDecoration.Underline
-                            )
-                            Spacer(modifier = Modifier.height(40.dp))
+                        if (isChallenging) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Spacer(modifier = Modifier.height(130.dp))
+                                Text(
+                                    modifier = Modifier.clickable {
+                                        coroutineScope.launch {
+                                            modalSheetState.show()
+                                        }
+                                    },
+                                    text = "그만할래요",
+                                    style = WalkieTypography.Body1.copy(SystemColor.Negative),
+                                    textDecoration = TextDecoration.Underline
+                                )
+                                Spacer(modifier = Modifier.height(40.dp))
+                            }
+                        } else {
+                            Spacer(modifier = Modifier.height(28.dp))
+                            WalkiePositiveButton(text = "도전하기")
                         }
-                    } else {
-                        Spacer(modifier = Modifier.height(28.dp))
-                        WalkiePositiveButton(text = "도전하기")
-                    }
 
+                    }
                 }
+            } ?: run {
+                WalkieCircularProgressIndicator(Modifier.fillMaxSize())
             }
-        } ?: run {
-            WalkieCircularProgressIndicator(Modifier.fillMaxSize())
         }
     }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -54,8 +54,8 @@ fun ChallengeMainScreen(
 
     ChallengeMainContent(
         state,
-        onChallengeItemClicked = {
-            val route = "challengeDetail/${it.id}"
+        onChallengeItemClicked = { challengePreview, isChallenging ->
+            val route = "challengeDetail/${challengePreview.id}/$isChallenging"
             navController.navigate(route)
         },
         onExpandButtonClicked = {
@@ -69,7 +69,7 @@ fun ChallengeMainScreen(
 @Composable
 fun ChallengeMainContent(
     state: ChallengeMainState,
-    onChallengeItemClicked: (ChallengePreview) -> Unit = {},
+    onChallengeItemClicked: (ChallengePreview, Boolean) -> Unit = { _, _ -> },
     onExpandButtonClicked: () -> Unit = {},
 ) {
 
@@ -107,7 +107,7 @@ fun ChallengeMainContent(
                                     Modifier.fillParentMaxWidth(0.9f),
                                     text = it.title
                                 ) {
-                                    onChallengeItemClicked(it)
+                                    onChallengeItemClicked(it, false)
                                 }
                             }
                         }
@@ -141,7 +141,7 @@ fun ChallengeMainContent(
                                 progress = it.progress!!,
                                 imageUrl = it.badgeImageUrl,
                             ) {
-                                onChallengeItemClicked(it)
+                                onChallengeItemClicked(it, true)
                             }
                             Spacer(modifier = Modifier.height(10.dp))
                         }
@@ -199,7 +199,7 @@ fun ChallengeMainContent(
                                             Modifier.fillParentMaxWidth(0.9f),
                                             text = it.title
                                         ) {
-                                            onChallengeItemClicked(it)
+                                            onChallengeItemClicked(it, false)
                                         }
                                         Spacer(modifier = Modifier.height(10.dp))
                                     }
@@ -267,7 +267,7 @@ fun ChallengeMainContent(
                                     ChallengeItem(
                                         text = challengePreview.title
                                     ) {
-                                        onChallengeItemClicked(challengePreview)
+                                        onChallengeItemClicked(challengePreview, false)
                                     }
                                     Spacer(modifier = Modifier.height(10.dp))
                                 }


### PR DESCRIPTION
## 개요
- 챌린지 상세 화면의 도전하기 버튼 분기 처리
  - 도전 중인 챌린지 여부 
- 챌린지 그만두기 확인 바텀 시트 구현 

### 동작 모습
![bottom_sheet](https://github.com/Team-Walkie/Walkie/assets/90144041/426e220d-1302-4041-9a59-44c409cfbb96)
