### PR TITLE
러닝 화면 전체 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
 }
 
 android {
@@ -99,4 +100,12 @@ dependencies {
 
     // RunningModule
     implementation("io.github.bngsh:runningdata:0.0.5")
+
+    // Room
+    val room_version = "2.5.0"
+    implementation("androidx.room:room-runtime:$room_version")
+    kapt("androidx.room:room-compiler:$room_version")
+    // optional - Kotlin Extensions and Coroutines support for Room
+    implementation("androidx.room:room-ktx:$room_version")
+    implementation("com.google.code.gson:gson:2.9.1")
 }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -1,10 +1,14 @@
 package com.whyranoid.walkie
 
+import androidx.room.Room
+import com.google.gson.Gson
+import com.whyranoid.data.AppDatabase
 import com.whyranoid.data.datasource.ChallengeDataSourceImpl
 import com.whyranoid.data.datasource.PostDataSourceImpl
 import com.whyranoid.data.datasource.UserDataSourceImpl
 import com.whyranoid.data.repository.ChallengeRepositoryImpl
 import com.whyranoid.data.repository.PostRepositoryImpl
+import com.whyranoid.data.repository.RunningHistoryRepositoryImpl
 import com.whyranoid.data.repository.RunningRepositoryImpl
 import com.whyranoid.data.repository.UserRepositoryImpl
 import com.whyranoid.domain.datasource.ChallengeDataSource
@@ -12,6 +16,7 @@ import com.whyranoid.domain.datasource.PostDataSource
 import com.whyranoid.domain.datasource.UserDataSource
 import com.whyranoid.domain.repository.ChallengeRepository
 import com.whyranoid.domain.repository.PostRepository
+import com.whyranoid.domain.repository.RunningHistoryRepository
 import com.whyranoid.domain.repository.RunningRepository
 import com.whyranoid.domain.repository.UserRepository
 import com.whyranoid.domain.usecase.GetChallengeDetailUseCase
@@ -32,6 +37,7 @@ import com.whyranoid.presentation.viewmodel.ChallengeMainViewModel
 import com.whyranoid.presentation.viewmodel.RunningEditViewModel
 import com.whyranoid.presentation.viewmodel.RunningViewModel
 import com.whyranoid.presentation.viewmodel.UserPageViewModel
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val viewModelModule = module {
@@ -39,7 +45,7 @@ val viewModelModule = module {
     single { ChallengeDetailViewModel(get()) }
     single { ChallengeExitViewModel(get()) }
     single { UserPageViewModel(get(), get(), get(), get()) }
-    factory { RunningViewModel(get(), get(), get(), get(), get()) }
+    factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
     factory { RunningEditViewModel() }
 }
 
@@ -48,6 +54,7 @@ val repositoryModule = module {
     single<PostRepository> { PostRepositoryImpl(get()) }
     single<UserRepository> { UserRepositoryImpl(get()) }
     single<RunningRepository> { RunningRepositoryImpl(get()) }
+    single<RunningHistoryRepository> { RunningHistoryRepositoryImpl(get(), get()) }
 }
 
 val dataSourceModule = module {
@@ -69,4 +76,20 @@ val useCaseModule = module {
     single { RunningFinishUseCase() }
     single { RunningPauseOrResumeUseCase() }
     single { RunningStartUseCase() }
+}
+
+val databaseModule = module {
+    single {
+        Room.databaseBuilder(
+            androidContext(),
+            AppDatabase::class.java,
+            "walkie_database",
+        ).build()
+    }
+
+    single {
+        get<AppDatabase>().runningHistoryDao()
+    }
+
+    single { Gson() }
 }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -29,6 +29,7 @@ import com.whyranoid.domain.usecase.running.RunningStartUseCase
 import com.whyranoid.presentation.viewmodel.ChallengeDetailViewModel
 import com.whyranoid.presentation.viewmodel.ChallengeExitViewModel
 import com.whyranoid.presentation.viewmodel.ChallengeMainViewModel
+import com.whyranoid.presentation.viewmodel.RunningEditViewModel
 import com.whyranoid.presentation.viewmodel.RunningViewModel
 import com.whyranoid.presentation.viewmodel.UserPageViewModel
 import org.koin.dsl.module
@@ -39,6 +40,7 @@ val viewModelModule = module {
     single { ChallengeExitViewModel(get()) }
     single { UserPageViewModel(get(), get(), get(), get()) }
     factory { RunningViewModel(get(), get(), get(), get(), get()) }
+    factory { RunningEditViewModel() }
 }
 
 val repositoryModule = module {

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -5,12 +5,14 @@ import com.whyranoid.data.datasource.PostDataSourceImpl
 import com.whyranoid.data.datasource.UserDataSourceImpl
 import com.whyranoid.data.repository.ChallengeRepositoryImpl
 import com.whyranoid.data.repository.PostRepositoryImpl
+import com.whyranoid.data.repository.RunningRepositoryImpl
 import com.whyranoid.data.repository.UserRepositoryImpl
 import com.whyranoid.domain.datasource.ChallengeDataSource
 import com.whyranoid.domain.datasource.PostDataSource
 import com.whyranoid.domain.datasource.UserDataSource
 import com.whyranoid.domain.repository.ChallengeRepository
 import com.whyranoid.domain.repository.PostRepository
+import com.whyranoid.domain.repository.RunningRepository
 import com.whyranoid.domain.repository.UserRepository
 import com.whyranoid.domain.usecase.GetChallengeDetailUseCase
 import com.whyranoid.domain.usecase.GetChallengePreviewsByTypeUseCase
@@ -36,13 +38,14 @@ val viewModelModule = module {
     single { ChallengeDetailViewModel(get()) }
     single { ChallengeExitViewModel(get()) }
     single { UserPageViewModel(get(), get(), get(), get()) }
-    factory { RunningViewModel(get(), get(), get(), get()) }
+    factory { RunningViewModel(get(), get(), get(), get(), get()) }
 }
 
 val repositoryModule = module {
     single<ChallengeRepository> { ChallengeRepositoryImpl(get()) }
     single<PostRepository> { PostRepositoryImpl(get()) }
     single<UserRepository> { UserRepositoryImpl(get()) }
+    single<RunningRepository> { RunningRepositoryImpl(get()) }
 }
 
 val dataSourceModule = module {

--- a/app/src/main/java/com/whyranoid/walkie/WalkieApplication.kt
+++ b/app/src/main/java/com/whyranoid/walkie/WalkieApplication.kt
@@ -7,7 +7,6 @@ import org.koin.core.context.startKoin
 
 class WalkieApplication : Application() {
     override fun onCreate() {
-
         startKoin {
             androidLogger()
             androidContext(this@WalkieApplication)
@@ -16,8 +15,9 @@ class WalkieApplication : Application() {
                     viewModelModule,
                     repositoryModule,
                     dataSourceModule,
-                    useCaseModule
-                )
+                    useCaseModule,
+                    databaseModule,
+                ),
             )
         }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -50,4 +50,7 @@ dependencies {
 
     // RunningModule
     implementation("io.github.bngsh:runningdata:0.0.5")
+
+    val googleLocationVersion = "21.0.1"
+    implementation("com.google.android.gms:play-services-location:$googleLocationVersion")
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
 }
 
 android {
@@ -15,6 +16,15 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments += mapOf(
+                    "room.schemaLocation" to "$projectDir/schemas",
+                    "room.incremental" to "true",
+                )
+            }
+        }
     }
 
     buildTypes {
@@ -53,4 +63,12 @@ dependencies {
 
     val googleLocationVersion = "21.0.1"
     implementation("com.google.android.gms:play-services-location:$googleLocationVersion")
+
+    // Room
+    val room_version = "2.5.0"
+    implementation("androidx.room:room-runtime:$room_version")
+    kapt("androidx.room:room-compiler:$room_version")
+    // optional - Kotlin Extensions and Coroutines support for Room
+    implementation("androidx.room:room-ktx:$room_version")
+    implementation("com.google.code.gson:gson:2.9.1")
 }

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 </manifest>

--- a/data/src/main/java/com/whyranoid/data/AppDataBase.kt
+++ b/data/src/main/java/com/whyranoid/data/AppDataBase.kt
@@ -1,0 +1,11 @@
+package com.whyranoid.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.whyranoid.data.datasource.runninghistory.RunningHistoryDao
+import com.whyranoid.data.model.RunningHistoryEntity
+
+@Database(entities = [RunningHistoryEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun runningHistoryDao(): RunningHistoryDao
+}

--- a/data/src/main/java/com/whyranoid/data/datasource/runninghistory/RunningHistoryDao.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/runninghistory/RunningHistoryDao.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.data.datasource.runninghistory
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.whyranoid.data.model.RunningHistoryEntity
+
+@Dao
+interface RunningHistoryDao {
+    @Insert
+    fun insert(runningHistoryEntity: RunningHistoryEntity)
+
+    @Query("SELECT * FROM running_history")
+    fun getAll(): List<RunningHistoryEntity>
+}

--- a/data/src/main/java/com/whyranoid/data/model/RunningHistoryEntity.kt
+++ b/data/src/main/java/com/whyranoid/data/model/RunningHistoryEntity.kt
@@ -1,0 +1,17 @@
+package com.whyranoid.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "running_history")
+data class RunningHistoryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long,
+    val distance: Double,
+    val pace: Double,
+    val totalRunningTime: Int,
+    val calories: Int,
+    val steps: Int,
+    val paths: String,
+    val finishedAt: Long,
+    val bitmap: String?,
+)

--- a/data/src/main/java/com/whyranoid/data/repository/RunningHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/RunningHistoryRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.whyranoid.data.repository
+
+import com.google.gson.Gson
+import com.whyranoid.data.datasource.runninghistory.RunningHistoryDao
+import com.whyranoid.data.model.RunningHistoryEntity
+import com.whyranoid.domain.model.running.RunningData
+import com.whyranoid.domain.model.running.RunningHistory
+import com.whyranoid.domain.model.running.RunningPosition
+import com.whyranoid.domain.repository.RunningHistoryRepository
+
+class RunningHistoryRepositoryImpl(
+    private val runningHistoryDao: RunningHistoryDao,
+    private val gson: Gson,
+) :
+    RunningHistoryRepository {
+    override suspend fun saveRunningHistory(runningHistory: RunningHistory): Result<RunningHistory> {
+        return kotlin.runCatching {
+            runningHistoryDao.insert(
+                RunningHistoryEntity(
+                    runningHistory.id,
+                    runningHistory.runningData.distance,
+                    runningHistory.runningData.pace,
+                    runningHistory.runningData.totalRunningTime,
+                    runningHistory.runningData.calories,
+                    runningHistory.runningData.steps,
+                    gson.toJson(runningHistory.runningData.paths),
+                    runningHistory.finishedAt,
+                    runningHistory.bitmap,
+                ),
+            )
+            runningHistory
+        }
+    }
+
+    override suspend fun getAll(): Result<List<RunningHistory>> {
+        return kotlin.runCatching {
+            runningHistoryDao.getAll().map {
+                RunningHistory(
+                    it.id,
+                    RunningData(
+                        it.distance,
+                        it.pace,
+                        it.totalRunningTime,
+                        it.calories,
+                        it.steps,
+                        gson.fromJson(it.paths, Array<Array<RunningPosition>>::class.java)
+                            .map { array ->
+                                array.toList()
+                            }.toList(),
+                    ),
+                    it.finishedAt,
+                    it.bitmap,
+                )
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/repository/RunningRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/RunningRepositoryImpl.kt
@@ -1,11 +1,29 @@
 package com.whyranoid.data.repository
 
+import android.content.Context
+import android.os.Looper
+import android.util.Log
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.whyranoid.domain.model.running.UserLocation
 import com.whyranoid.domain.repository.RunningRepository
 import com.whyranoid.runningdata.RunningDataManager
+import com.whyranoid.runningdata.model.RunningState
+import kotlinx.coroutines.flow.MutableStateFlow
 
-class RunningRepositoryImpl : RunningRepository {
+class RunningRepositoryImpl(context: Context) : RunningRepository {
 
     private val runningDataManager = RunningDataManager.getInstance()
+    private val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+    private val locationRequest =
+        LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1000L).build()
+    private lateinit var locationCallback: LocationCallback
+
+    override val userLocationState: MutableStateFlow<UserLocation> =
+        MutableStateFlow(UserLocation.NotTracking)
 
     override suspend fun startRunning() {
     }
@@ -20,5 +38,37 @@ class RunningRepositoryImpl : RunningRepository {
 
     override suspend fun finishRunning() {
         TODO("Not yet implemented")
+    }
+
+    override fun listenLocation() {
+        if (userLocationState.value is UserLocation.Tracking) return
+        if ((runningDataManager.runningState.value is RunningState.NotRunning).not()) return
+        locationCallback = object : LocationCallback() {
+            override fun onLocationResult(locationResult: LocationResult) {
+                locationResult.lastLocation?.let { location ->
+                    userLocationState.value =
+                        UserLocation.Tracking(location.latitude, location.longitude)
+                    Log.d("listenLocation", "listenLocation")
+                } ?: run {
+                    removeListener()
+                }
+            }
+        }
+        try {
+            fusedLocationClient.requestLocationUpdates(
+                locationRequest,
+                locationCallback,
+                Looper.getMainLooper(),
+            )
+        } catch (e: SecurityException) {
+            removeListener()
+        } catch (e: Exception) {
+            removeListener()
+        }
+    }
+
+    override fun removeListener() {
+        userLocationState.value = UserLocation.NotTracking
+        fusedLocationClient.removeLocationUpdates(locationCallback)
     }
 }

--- a/data/src/main/java/com/whyranoid/data/repository/RunningRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/RunningRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.whyranoid.data.repository
 
 import android.content.Context
 import android.os.Looper
-import android.util.Log
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
@@ -48,7 +47,6 @@ class RunningRepositoryImpl(context: Context) : RunningRepository {
                 locationResult.lastLocation?.let { location ->
                     userLocationState.value =
                         UserLocation.Tracking(location.latitude, location.longitude)
-                    Log.d("listenLocation", "listenLocation")
                 } ?: run {
                     removeListener()
                 }
@@ -68,7 +66,10 @@ class RunningRepositoryImpl(context: Context) : RunningRepository {
     }
 
     override fun removeListener() {
-        userLocationState.value = UserLocation.NotTracking
         fusedLocationClient.removeLocationUpdates(locationCallback)
+    }
+
+    override fun removeUserLocation() {
+        userLocationState.value = UserLocation.NotTracking
     }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -10,4 +10,7 @@ java {
 
 dependencies {
     implementation(libs.javax.inject)
+
+    // Coroutine
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 }

--- a/domain/src/main/java/com/whyranoid/domain/model/running/RunningHistory.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/running/RunningHistory.kt
@@ -3,5 +3,6 @@ package com.whyranoid.domain.model.running
 data class RunningHistory(
     val id: Long,
     val runningData: RunningData,
-    val finishedAt: Long
+    val finishedAt: Long,
+    val bitmap: String?,
 )

--- a/domain/src/main/java/com/whyranoid/domain/model/running/UserLocation.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/running/UserLocation.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.domain.model.running
+
+sealed class UserLocation {
+    object NotTracking : UserLocation()
+    data class Tracking(val lat: Double, val lng: Double) : UserLocation()
+}

--- a/domain/src/main/java/com/whyranoid/domain/repository/RunningHistoryRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/RunningHistoryRepository.kt
@@ -1,0 +1,8 @@
+package com.whyranoid.domain.repository
+
+import com.whyranoid.domain.model.running.RunningHistory
+
+interface RunningHistoryRepository {
+    suspend fun saveRunningHistory(runningHistory: RunningHistory): Result<RunningHistory>
+    suspend fun getAll(): Result<List<RunningHistory>>
+}

--- a/domain/src/main/java/com/whyranoid/domain/repository/RunningRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/RunningRepository.kt
@@ -14,4 +14,5 @@ interface RunningRepository {
     fun listenLocation()
 
     fun removeListener()
+    fun removeUserLocation()
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/RunningRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/RunningRepository.kt
@@ -1,8 +1,17 @@
 package com.whyranoid.domain.repository
 
+import com.whyranoid.domain.model.running.UserLocation
+import kotlinx.coroutines.flow.StateFlow
+
 interface RunningRepository {
+
+    val userLocationState: StateFlow<UserLocation>
+
     suspend fun startRunning()
     suspend fun pauseRunning()
     suspend fun resumeRunning()
     suspend fun finishRunning()
+    fun listenLocation()
+
+    fun removeListener()
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -126,4 +126,8 @@ dependencies {
 
     // RunningModule
     implementation("io.github.bngsh:runningdata:0.0.5")
+
+    // Google Location
+    val googleLocationVersion = "21.0.1"
+    implementation("com.google.android.gms:play-services-location:$googleLocationVersion")
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -130,4 +130,9 @@ dependencies {
     // Google Location
     val googleLocationVersion = "21.0.1"
     implementation("com.google.android.gms:play-services-location:$googleLocationVersion")
+
+    // Paging
+    implementation("androidx.paging:paging-runtime:3.1.1")
+    implementation("androidx.paging:paging-compose:3.2.0-rc01")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application>
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application>
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"

--- a/presentation/src/main/java/com/whyranoid/presentation/model/running/RunningHistoryUiModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/running/RunningHistoryUiModel.kt
@@ -1,0 +1,33 @@
+package com.whyranoid.presentation.model.running
+
+import android.graphics.Bitmap
+import com.google.gson.Gson
+import com.whyranoid.domain.model.running.RunningHistory
+import com.whyranoid.domain.model.running.RunningPosition
+import com.whyranoid.presentation.util.BitmapConverter
+
+data class RunningHistoryUiModel(
+    val id: Long,
+    val finishedAt: Long,
+    val bitmap: Bitmap?,
+    val distance: Double,
+    val pace: Double,
+    val totalRunningTime: Int,
+    val calories: Int,
+    val steps: Int,
+    val paths: List<List<RunningPosition>>,
+)
+
+fun RunningHistory.toRunningHistoryUiModel(gson: Gson): RunningHistoryUiModel {
+    return RunningHistoryUiModel(
+        this.id,
+        this.finishedAt,
+        BitmapConverter.stringToBitmap(this.bitmap),
+        this.runningData.distance,
+        this.runningData.pace,
+        this.runningData.totalRunningTime,
+        this.runningData.calories,
+        this.runningData.steps,
+        this.runningData.paths,
+    )
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/model/running/SavingState.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/running/SavingState.kt
@@ -1,0 +1,8 @@
+package com.whyranoid.presentation.model.running
+
+import com.whyranoid.runningdata.model.RunningFinishData
+
+sealed class SavingState {
+    data class Start(val runningFinishData: RunningFinishData) : SavingState()
+    object Done : SavingState()
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/model/running/SelectedImage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/running/SelectedImage.kt
@@ -1,0 +1,8 @@
+package com.whyranoid.presentation.model.running
+
+import android.net.Uri
+
+sealed class SelectedImage {
+    object None : SelectedImage()
+    data class Selected(val uri: Uri) : SelectedImage()
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/reusable/CircleProgressWithText.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/reusable/CircleProgressWithText.kt
@@ -1,0 +1,42 @@
+package com.whyranoid.presentation.reusable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.whyranoid.presentation.theme.WalkieColor
+import com.whyranoid.presentation.theme.WalkieTypography
+
+@Composable
+fun CircleProgressWithText(
+    modifier: Modifier = Modifier,
+    text: String,
+) {
+    Box(modifier = modifier.fillMaxSize().alpha(0.5f).background(WalkieColor.GrayDefault))
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = modifier.width(200.dp).height(160.dp).align(Alignment.Center)
+                .clip(RoundedCornerShape(20.dp)).background(Color.White),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(text, style = WalkieTypography.SubTitle)
+            Spacer(modifier = Modifier.height(20.dp))
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/reusable/GalleryGrid.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/reusable/GalleryGrid.kt
@@ -1,0 +1,93 @@
+package com.whyranoid.presentation.reusable
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.compose.collectAsLazyPagingItems
+import coil.compose.AsyncImage
+import com.whyranoid.presentation.theme.WalkieColor
+import com.whyranoid.presentation.viewmodel.RunningEditViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun GalleryGrid(
+    modifier: Modifier = Modifier,
+    column: Int,
+    onImageSelected: (Uri) -> Unit,
+) {
+    val viewModel = koinViewModel<RunningEditViewModel>()
+    val selectedImageState = viewModel.selectedState.collectAsStateWithLifecycle()
+    val images = viewModel.getImages(LocalContext.current).collectAsLazyPagingItems()
+
+    LazyVerticalGrid(
+        modifier = modifier,
+        columns = GridCells.Fixed(column),
+        contentPadding = PaddingValues(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        items(images.itemCount) { index ->
+            images[index]?.let { uri ->
+                GalleryImage(uri, isSelected = uri == selectedImageState.value) {
+                    viewModel.select(uri)
+                    onImageSelected(uri)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GalleryImage(
+    uri: Uri,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    onClick: () -> Unit,
+) {
+    val expandState = remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .border(
+                width = if (isSelected) 2.dp else 0.dp,
+                color = WalkieColor.Primary,
+                shape = RectangleShape,
+            )
+            .background(Color.Gray)
+            .zIndex(if (expandState.value) 1f else 0f)
+            .fillMaxSize()
+            .then(modifier)
+            .clickable { onClick() },
+    ) {
+        AsyncImage(
+            model = uri,
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .align(Alignment.Center),
+            contentScale = ContentScale.Crop,
+        )
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -92,6 +92,7 @@ fun AppScreen(startWorker: () -> Unit) {
                                     ImageVector.vectorResource(requireNotNull(if (selected) screen.iconSelected else screen.icon)),
                                     contentDescription = null,
                                     modifier = Modifier.size(24.dp),
+                                    tint = if (selected) WalkieColor.Primary else WalkieColor.GrayDefault,
                                 )
                             },
                             label = {

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -67,6 +67,7 @@ fun AppScreen(startWorker: () -> Unit) {
             context,
             arrayOf(
                 Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
             ),
             launcherMultiplePermissions,
         )

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -77,6 +77,7 @@ import com.whyranoid.domain.model.running.UserLocation
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.model.running.SavingState
 import com.whyranoid.presentation.model.running.TrackingMode
+import com.whyranoid.presentation.reusable.CircleProgressWithText
 import com.whyranoid.presentation.reusable.GalleryGrid
 import com.whyranoid.presentation.theme.WalkieColor
 import com.whyranoid.presentation.theme.WalkieTypography
@@ -169,6 +170,10 @@ fun RunningContent(
         onEditClose = onEditClose,
         onTakeSnapShot = onTakeSnapShot,
     )
+
+    state.savingState.getDataOrNull()?.let {
+        if (it is SavingState.Start) CircleProgressWithText(text = "저장 중")
+    }
 }
 
 @OptIn(ExperimentalNaverMapApi::class)
@@ -255,7 +260,6 @@ fun RunningMapScreen(
         }
     }
 
-    // TODO 6. 저장하기 구현, 8.bitmap 위 글자(날짜), 10. 사진 비율
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -270,7 +274,6 @@ fun RunningMapScreen(
                 state.savingState.getDataOrNull()?.let { savingState ->
                     if (savingState is SavingState.Start) {
                         map.takeSnapshot { bitmap ->
-                            Log.d("MapEffect", "MapEffect: $bitmap")
                             onSaveHistory(bitmap, savingState.runningFinishData)
                         }
                     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -120,7 +120,9 @@ fun RunningContent(
             RunningInfoScreen(modifier = Modifier.height(280.dp), state = state)
         }
         RunningBottomButton(
-            modifier = Modifier.height(50.dp).width(80.dp),
+            modifier = Modifier
+                .height(50.dp)
+                .width(80.dp),
             state = state,
             onStartRunning = onStartRunning,
             onPauseRunning = onPauseRunning,
@@ -158,6 +160,7 @@ fun RunningMapScreen(
                 isScaleBarEnabled = false,
                 isZoomControlEnabled = false,
                 isCompassEnabled = false,
+                isLogoClickEnabled = false,
             ),
         )
     }
@@ -172,7 +175,7 @@ fun RunningMapScreen(
         }
     }
 
-    // TODO 1. 종료시 아이콘 사라짐, 2. 종료시 화면 고정(모각런 참고), 3. 종료시 상단바 생성, 4. 러닝 시작 전에도 위치 추적, 5. 갤러리 구현, 6. 저장하기 구현
+    // TODO 1. 종료시 아이콘 사라짐, 2. 종료시 화면 고정(모각런 참고), 3. 종료시 상단바 생성, 5. 갤러리 구현, 6. 저장하기 구현
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -226,37 +229,75 @@ fun RunningMapScreen(
                 }
             }
         }
-        Row(
-            modifier = Modifier.wrapContentSize().align(Alignment.BottomEnd).padding(16.dp),
-        ) {
-            Icon(
-                modifier = Modifier.clip(CircleShape).clickable {
-                    state.runningState.getDataOrNull()?.runningData?.lastLocation?.let { location ->
-                        if (state.trackingModeState.getDataOrNull() == TrackingMode.NONE) {
-                            cameraPositionState.move(
-                                CameraUpdate.scrollTo(LatLng(location)),
-                            )
-                        }
-                    }
-                    onClickTrackingModeButton()
-                }.background(Color.White).size(32.dp).padding(4.dp),
-                imageVector = Icons.Default.MyLocation,
-                contentDescription = "",
-                tint = WalkieColor.Primary,
-            )
-
+        state.runningFinishState.getDataOrNull()?.let { finData ->
+            // 러닝 종료
             Row(
-                modifier = Modifier.padding(start = 8.dp).clip(RoundedCornerShape(8.dp))
-                    .clickable { /* TODO */ }.background(Color.White).height(32.dp)
-                    .wrapContentWidth().padding(4.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                listOf(
+                    "%.2f".format(finData.runningHistory.totalDistance.div(1000.toDouble())),
+                    finData.runningHistory.totalRunningTime.toRunningTime(),
+                    finData.runningHistory.pace.toPace(),
+                ).forEach {
+                    Text(
+                        it,
+                        style = WalkieTypography.Title,
+                    )
+                }
+            }
+        } ?: run {
+            // 러닝 중
+            Row(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
             ) {
                 Icon(
-                    modifier = Modifier.fillMaxHeight().padding(end = 4.dp),
-                    imageVector = Icons.Default.Favorite,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable {
+                            state.runningState.getDataOrNull()?.runningData?.lastLocation?.let { location ->
+                                if (state.trackingModeState.getDataOrNull() == TrackingMode.NONE) {
+                                    cameraPositionState.move(
+                                        CameraUpdate.scrollTo(LatLng(location)),
+                                    )
+                                }
+                            }
+                            onClickTrackingModeButton()
+                        }
+                        .background(Color.White)
+                        .size(32.dp)
+                        .padding(4.dp),
+                    imageVector = Icons.Default.MyLocation,
                     contentDescription = "",
                     tint = WalkieColor.Primary,
                 )
-                Text(text = "0")
+
+                Row(
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { /* TODO */ }
+                        .background(Color.White)
+                        .height(32.dp)
+                        .wrapContentWidth()
+                        .padding(4.dp),
+                ) {
+                    Icon(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(end = 4.dp),
+                        imageVector = Icons.Default.Favorite,
+                        contentDescription = "",
+                        tint = WalkieColor.Primary,
+                    )
+                    Text(text = "0")
+                }
             }
         }
     }
@@ -268,14 +309,21 @@ fun RunningInfoScreen(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.padding(bottom = 66.dp).background(Color.White),
+        modifier = modifier
+            .padding(bottom = 66.dp)
+            .background(Color.White),
     ) {
         // 거리, 런닝 시간
         Row(
-            modifier = Modifier.fillMaxWidth().height(120.dp).padding(top = 20.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .padding(top = 20.dp),
         ) {
             Column(
-                Modifier.wrapContentHeight().weight(0.4f),
+                Modifier
+                    .wrapContentHeight()
+                    .weight(0.4f),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -303,7 +351,9 @@ fun RunningInfoScreen(
             }
 
             Column(
-                Modifier.wrapContentHeight().weight(0.6f),
+                Modifier
+                    .wrapContentHeight()
+                    .weight(0.6f),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -324,10 +374,14 @@ fun RunningInfoScreen(
 
         // 페이스 칼로리 걸음수
         Row(
-            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
         ) {
             Column(
-                Modifier.wrapContentHeight().weight(1f),
+                Modifier
+                    .wrapContentHeight()
+                    .weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
@@ -343,7 +397,9 @@ fun RunningInfoScreen(
             }
 
             Column(
-                Modifier.wrapContentHeight().weight(1f),
+                Modifier
+                    .wrapContentHeight()
+                    .weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
@@ -365,7 +421,9 @@ fun RunningInfoScreen(
             }
 
             Column(
-                Modifier.wrapContentHeight().weight(1f),
+                Modifier
+                    .wrapContentHeight()
+                    .weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
@@ -394,14 +452,19 @@ fun RunningBottomButton(
     onFinishRunning: () -> Unit,
 ) {
     Box(
-        modifier = Modifier.fillMaxSize().padding(bottom = 20.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = 20.dp),
         contentAlignment = Alignment.BottomCenter,
     ) {
         state.runningFinishState.getDataOrNull()?.let { finState ->
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(modifier = Modifier.padding(bottom = 8.dp), text = "런닝을 종료했습니다.")
                 Button(
-                    modifier = Modifier.height(50.dp).fillMaxWidth().padding(horizontal = 20.dp),
+                    modifier = Modifier
+                        .height(50.dp)
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp),
                     onClick = { },
                     shape = RoundedCornerShape(12.dp),
                 ) {
@@ -415,7 +478,9 @@ fun RunningBottomButton(
             when (runningState) {
                 is RunningState.NotRunning -> {
                     Button(
-                        modifier = Modifier.height(50.dp).width(160.dp),
+                        modifier = Modifier
+                            .height(50.dp)
+                            .width(160.dp),
                         onClick = onStartRunning,
                     ) {
                         Text("러닝 시작", style = WalkieTypography.Title)
@@ -423,11 +488,15 @@ fun RunningBottomButton(
                 }
                 is RunningState.Paused -> {
                     Row(
-                        Modifier.wrapContentSize().border(
-                            width = 1.dp,
-                            color = WalkieColor.GrayDefault,
-                            shape = CircleShape,
-                        ).clip(CircleShape).background(Color.White),
+                        Modifier
+                            .wrapContentSize()
+                            .border(
+                                width = 1.dp,
+                                color = WalkieColor.GrayDefault,
+                                shape = CircleShape,
+                            )
+                            .clip(CircleShape)
+                            .background(Color.White),
                     ) {
                         IconButton(modifier = modifier, onClick = { onResumeRunning() }) {
                             Icon(Icons.Default.PlayArrow, contentDescription = "")
@@ -443,11 +512,15 @@ fun RunningBottomButton(
                 }
                 is RunningState.Running -> {
                     Row(
-                        Modifier.wrapContentSize().border(
-                            width = 1.dp,
-                            color = WalkieColor.GrayDefault,
-                            shape = CircleShape,
-                        ).clip(CircleShape).background(Color.White),
+                        Modifier
+                            .wrapContentSize()
+                            .border(
+                                width = 1.dp,
+                                color = WalkieColor.GrayDefault,
+                                shape = CircleShape,
+                            )
+                            .clip(CircleShape)
+                            .background(Color.White),
                     ) {
                         IconButton(modifier = modifier, onClick = { onPauseRunning() }) {
                             Icon(Icons.Default.Pause, contentDescription = "")

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -161,6 +162,7 @@ fun RunningMapScreen(
                 isZoomControlEnabled = false,
                 isCompassEnabled = false,
                 isLogoClickEnabled = false,
+                logoMargin = PaddingValues(bottom = 44.dp, start = 18.dp),
             ),
         )
     }
@@ -175,7 +177,7 @@ fun RunningMapScreen(
         }
     }
 
-    // TODO 1. 종료시 아이콘 사라짐, 2. 종료시 화면 고정(모각런 참고), 3. 종료시 상단바 생성, 5. 갤러리 구현, 6. 저장하기 구현
+    // TODO 1. 종료시 아이콘 사라짐, 2. 종료시 화면 고정(모각런 참고), 3. 종료시 상단바 생성, 4. 네이버 로고 위치 변경, 5. 갤러리 구현, 6. 저장하기 구현
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -230,12 +232,27 @@ fun RunningMapScreen(
             }
         }
         state.runningFinishState.getDataOrNull()?.let { finData ->
-            // 러닝 종료
+            // 러닝 종료 시
+            // 탑 앱바
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .background(Color.White),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+//                Icon()
+//                Text()
+//                Icon()
+            }
+
+            // 지도 하단 정보
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter)
-                    .padding(16.dp),
+                    .padding(bottom = 12.dp)
+                    .padding(horizontal = 20.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 listOf(
@@ -253,10 +270,32 @@ fun RunningMapScreen(
             // 러닝 중
             Row(
                 modifier = Modifier
-                    .wrapContentSize()
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp),
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
+                Row(
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { /* TODO */ }
+                        .background(Color.White)
+                        .height(24.dp)
+                        .wrapContentWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(4.dp),
+                        imageVector = Icons.Default.Favorite,
+                        contentDescription = "",
+                        tint = WalkieColor.Primary,
+                    )
+                    Text(text = "0", style = WalkieTypography.Body1, modifier = Modifier.padding(end = 4.dp))
+                }
+
                 Icon(
                     modifier = Modifier
                         .clip(CircleShape)
@@ -271,33 +310,12 @@ fun RunningMapScreen(
                             onClickTrackingModeButton()
                         }
                         .background(Color.White)
-                        .size(32.dp)
+                        .size(24.dp)
                         .padding(4.dp),
                     imageVector = Icons.Default.MyLocation,
                     contentDescription = "",
                     tint = WalkieColor.Primary,
                 )
-
-                Row(
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .clickable { /* TODO */ }
-                        .background(Color.White)
-                        .height(32.dp)
-                        .wrapContentWidth()
-                        .padding(4.dp),
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .padding(end = 4.dp),
-                        imageVector = Icons.Default.Favorite,
-                        contentDescription = "",
-                        tint = WalkieColor.Primary,
-                    )
-                    Text(text = "0")
-                }
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -62,6 +62,7 @@ import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.overlay.OverlayImage
 import com.whyranoid.domain.model.running.UserLocation
 import com.whyranoid.presentation.R
+import com.whyranoid.presentation.model.running.SelectedImage
 import com.whyranoid.presentation.model.running.TrackingMode
 import com.whyranoid.presentation.reusable.GalleryGrid
 import com.whyranoid.presentation.theme.WalkieColor
@@ -196,7 +197,7 @@ fun RunningMapScreen(
         }
     }
 
-    // TODO 2. 종료시 화면 고정(모각런 참고), 6. 저장하기 구현
+    // TODO 2. 종료시 화면 고정(모각런 참고), 6. 저장하기 구현, 7. 갤러리 아래 패딩 및 버튼 변경
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -375,11 +376,10 @@ fun RunningInfoScreen(
     modifier: Modifier = Modifier,
     onSelectImage: (Uri) -> Unit,
 ) {
-    state.editState.getDataOrNull()?.let { editState ->
+    state.editState.getDataOrNull()?.let { _ ->
         GalleryGrid(
             column = 3,
             modifier = modifier
-                .padding(bottom = 66.dp)
                 .background(Color.White),
         ) { uri -> onSelectImage(uri) }
         return
@@ -536,7 +536,7 @@ fun RunningBottomButton(
     ) {
         // 편집 중
         state.editState.getDataOrNull()?.let { editState ->
-            if (true) { // TODO editState.backgroundSelected
+            if (editState is SelectedImage.Selected) {
                 Button(
                     modifier = Modifier
                         .height(50.dp)

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.presentation.screens.running
 
 import android.location.Location
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -100,6 +101,7 @@ fun RunningScreen(
         viewModel::finishRunning,
         viewModel::openEdit,
         viewModel::closeEdit,
+        viewModel::selectImage,
     )
 }
 
@@ -114,6 +116,7 @@ fun RunningContent(
     onFinishRunning: () -> Unit,
     onEditOpen: () -> Unit,
     onEditClose: () -> Unit,
+    selectImage: (Uri) -> Unit,
 ) {
     Box {
         Column(
@@ -127,7 +130,11 @@ fun RunningContent(
                 onEditOpen,
                 onEditClose,
             )
-            RunningInfoScreen(modifier = Modifier.height(280.dp), state = state)
+            RunningInfoScreen(
+                modifier = Modifier.height(280.dp),
+                state = state,
+                onSelectImage = selectImage,
+            )
         }
         RunningBottomButton(
             modifier = Modifier
@@ -189,7 +196,7 @@ fun RunningMapScreen(
         }
     }
 
-    // TODO 1. 종료시 아이콘 사라짐, 2. 종료시 화면 고정(모각런 참고), 3. 종료시 상단바 생성, 4. 네이버 로고 위치 변경, 5. 갤러리 구현, 6. 저장하기 구현
+    // TODO 2. 종료시 화면 고정(모각런 참고), 6. 저장하기 구현
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -366,6 +373,7 @@ fun RunningMapScreen(
 fun RunningInfoScreen(
     state: RunningScreenState,
     modifier: Modifier = Modifier,
+    onSelectImage: (Uri) -> Unit,
 ) {
     state.editState.getDataOrNull()?.let { editState ->
         GalleryGrid(
@@ -373,9 +381,7 @@ fun RunningInfoScreen(
             modifier = modifier
                 .padding(bottom = 66.dp)
                 .background(Color.White),
-        ) { uri ->
-            // TODO 이미지 보여주기 onImageSelected()
-        }
+        ) { uri -> onSelectImage(uri) }
         return
     }
     Column(

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -410,7 +410,7 @@ fun RunningMapScreen(
             }
         }
 
-        // 러닝 종료 시
+        // 러닝 종료 시 오버레이 Overlay  제외
         state.runningFinishState.getDataOrNull()?.let { finData ->
             if (state.editState.getDataOrNull() != true) {
                 Text(
@@ -488,6 +488,12 @@ fun RunningMapScreen(
                                 if (state.trackingModeState.getDataOrNull() == TrackingMode.NONE) {
                                     cameraPositionState.move(
                                         CameraUpdate.scrollTo(LatLng(location)),
+                                    )
+                                }
+                            } ?: state.userLocationState.getDataOrNull()?.let { location ->
+                                if (location is UserLocation.Tracking) {
+                                    cameraPositionState.move(
+                                        CameraUpdate.scrollTo(LatLng(location.lat, location.lng)),
                                     )
                                 }
                             }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/running/RunningScreen.kt
@@ -1,7 +1,12 @@
 package com.whyranoid.presentation.screens.running
 
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
 import android.location.Location
 import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -39,41 +44,52 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationSource
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.GroundOverlay
 import com.naver.maps.map.compose.LocationOverlay
 import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapEffect
 import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapType
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.NaverMapComposable
 import com.naver.maps.map.compose.PathOverlay
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.overlay.OverlayImage
 import com.whyranoid.domain.model.running.UserLocation
 import com.whyranoid.presentation.R
-import com.whyranoid.presentation.model.running.SelectedImage
+import com.whyranoid.presentation.model.running.SavingState
 import com.whyranoid.presentation.model.running.TrackingMode
 import com.whyranoid.presentation.reusable.GalleryGrid
 import com.whyranoid.presentation.theme.WalkieColor
 import com.whyranoid.presentation.theme.WalkieTypography
+import com.whyranoid.presentation.util.dpToPx
 import com.whyranoid.presentation.util.toPace
 import com.whyranoid.presentation.util.toRunningTime
 import com.whyranoid.presentation.viewmodel.RunningScreenState
 import com.whyranoid.presentation.viewmodel.RunningViewModel
 import com.whyranoid.presentation.viewmodel.RunningViewModel.Companion.MAP_MAX_ZOOM
 import com.whyranoid.presentation.viewmodel.RunningViewModel.Companion.MAP_MIN_ZOOM
+import com.whyranoid.runningdata.model.RunningFinishData
 import com.whyranoid.runningdata.model.RunningState
+import kotlinx.coroutines.CoroutineScope
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 
@@ -103,6 +119,8 @@ fun RunningScreen(
         viewModel::openEdit,
         viewModel::closeEdit,
         viewModel::selectImage,
+        viewModel::saveHistory,
+        viewModel::takeSnapShot,
     )
 }
 
@@ -118,37 +136,39 @@ fun RunningContent(
     onEditOpen: () -> Unit,
     onEditClose: () -> Unit,
     selectImage: (Uri) -> Unit,
+    saveHistory: (Bitmap, RunningFinishData) -> Unit,
+    onTakeSnapShot: (RunningFinishData) -> Unit,
 ) {
-    Box {
-        Column(
-            modifier = Modifier.fillMaxHeight(),
-        ) {
-            RunningMapScreen(
-                modifier = Modifier.weight(1f, false),
-                state,
-                onClickTrackingModeButton,
-                onTrackingCanceledByGesture,
-                onEditOpen,
-                onEditClose,
-            )
-            RunningInfoScreen(
-                modifier = Modifier.height(280.dp),
-                state = state,
-                onSelectImage = selectImage,
-            )
-        }
-        RunningBottomButton(
-            modifier = Modifier
-                .height(50.dp)
-                .width(80.dp),
+    Column(
+        modifier = Modifier.fillMaxHeight(),
+    ) {
+        RunningMapScreen(
+            modifier = Modifier.weight(1f, false),
+            state,
+            onClickTrackingModeButton,
+            onTrackingCanceledByGesture,
+            onEditOpen,
+            onEditClose,
+            saveHistory,
+        )
+        RunningInfoScreen(
+            modifier = Modifier.height(280.dp),
             state = state,
-            onStartRunning = onStartRunning,
-            onPauseRunning = onPauseRunning,
-            onResumeRunning = onResumeRunning,
-            onFinishRunning = onFinishRunning,
-            onEditClose = onEditClose,
+            onSelectImage = selectImage,
         )
     }
+    RunningBottomButton(
+        modifier = Modifier
+            .height(50.dp)
+            .width(80.dp),
+        state = state,
+        onStartRunning = onStartRunning,
+        onPauseRunning = onPauseRunning,
+        onResumeRunning = onResumeRunning,
+        onFinishRunning = onFinishRunning,
+        onEditClose = onEditClose,
+        onTakeSnapShot = onTakeSnapShot,
+    )
 }
 
 @OptIn(ExperimentalNaverMapApi::class)
@@ -160,21 +180,19 @@ fun RunningMapScreen(
     onTrackingCanceledByGesture: () -> Unit,
     onEditOpen: () -> Unit,
     onEditClose: () -> Unit,
+    onSaveHistory: (Bitmap, RunningFinishData) -> Unit,
 ) {
-    val mapProperties by remember {
+    var mapProperties by remember {
         mutableStateOf(
             MapProperties(
                 maxZoom = MAP_MAX_ZOOM,
                 minZoom = MAP_MIN_ZOOM,
-                locationTrackingMode = when (state.trackingModeState.getDataOrNull()) {
-                    TrackingMode.FOLLOW -> LocationTrackingMode.Follow
-                    TrackingMode.NO_FOLLOW -> LocationTrackingMode.NoFollow
-                    else -> LocationTrackingMode.Follow
-                },
+                locationTrackingMode = LocationTrackingMode.Follow,
             ),
         )
     }
-    val mapUiSettings by remember {
+
+    var mapUiSettings by remember {
         mutableStateOf(
             MapUiSettings(
                 isLocationButtonEnabled = false,
@@ -187,17 +205,57 @@ fun RunningMapScreen(
         )
     }
 
+    mapUiSettings = MapUiSettings(
+        isScrollGesturesEnabled = state.runningFinishState.getDataOrNull() == null,
+        isZoomGesturesEnabled = state.runningFinishState.getDataOrNull() == null,
+        isLocationButtonEnabled = false,
+        isScaleBarEnabled = false,
+        isZoomControlEnabled = false,
+        isCompassEnabled = false,
+        isLogoClickEnabled = false,
+        logoMargin = PaddingValues(bottom = 44.dp, start = 18.dp),
+    )
+
+    mapProperties = MapProperties(
+        mapType = if (state.selectedImage.getDataOrNull() != null) MapType.None else MapType.Basic,
+        maxZoom = MAP_MAX_ZOOM,
+        minZoom = MAP_MIN_ZOOM,
+        locationTrackingMode = LocationTrackingMode.Follow,
+    )
+
     val cameraPositionState = rememberCameraPositionState().apply {
-        state.trackingModeState.getDataOrNull()?.let { trackingMode ->
-            state.runningState.getDataOrNull()?.runningData?.lastLocation?.let { location ->
-                if (trackingMode == TrackingMode.FOLLOW) {
-                    move(CameraUpdate.scrollTo(LatLng(location)))
+        state.runningFinishState.getDataOrNull()?.let { runningFinishData ->
+            var maxLat = Double.MIN_VALUE
+            var minLat = Double.MAX_VALUE
+            var maxLng = Double.MIN_VALUE
+            var minLng = Double.MAX_VALUE
+            runningFinishData.runningPositionList.flatten().map { position ->
+                maxLat = maxOf(maxLat, position.latitude)
+                minLat = minOf(minLat, position.latitude)
+                maxLng = maxOf(maxLng, position.longitude)
+                minLng = minOf(minLng, position.longitude)
+            }
+            val cameraUpdate = CameraUpdate.fitBounds(
+                LatLngBounds(
+                    LatLng(maxLat, maxLng),
+                    LatLng(minLat, minLng),
+                ),
+                100.dpToPx(LocalContext.current),
+            )
+            move(cameraUpdate)
+        } ?: run {
+            // 러닝중일 때 카메라 위치
+            state.trackingModeState.getDataOrNull()?.let { trackingMode ->
+                state.runningState.getDataOrNull()?.runningData?.lastLocation?.let { location ->
+                    if (trackingMode == TrackingMode.FOLLOW) {
+                        move(CameraUpdate.scrollTo(LatLng(location)))
+                    }
                 }
             }
         }
     }
 
-    // TODO 2. 종료시 화면 고정(모각런 참고), 6. 저장하기 구현, 7. 갤러리 아래 패딩 및 버튼 변경
+    // TODO 6. 저장하기 구현, 8.bitmap 위 글자(날짜), 10. 사진 비율
     Box(modifier) {
         NaverMap(
             cameraPositionState = cameraPositionState,
@@ -208,6 +266,18 @@ fun RunningMapScreen(
         ) {
             if (cameraPositionState.cameraUpdateReason.value == CameraUpdate.REASON_GESTURE) onTrackingCanceledByGesture()
 
+            MapEffect(state.savingState) { map ->
+                state.savingState.getDataOrNull()?.let { savingState ->
+                    if (savingState is SavingState.Start) {
+                        map.takeSnapshot { bitmap ->
+                            Log.d("MapEffect", "MapEffect: $bitmap")
+                            onSaveHistory(bitmap, savingState.runningFinishData)
+                        }
+                    }
+                }
+            }
+
+            // 러닝 시작전 사용자 위치
             state.userLocationState.getDataOrNull()?.let {
                 if (it is UserLocation.Tracking) {
                     val location = Location("").apply {
@@ -226,6 +296,7 @@ fun RunningMapScreen(
                 }
             }
 
+            // 러닝 중 사용자 경로 표시
             state.runningState.getDataOrNull()?.let {
                 it.runningData.lastLocation?.let { location ->
                     LocationOverlay(
@@ -234,59 +305,123 @@ fun RunningMapScreen(
                     )
                 }
 
-                it.runningData.runningPositionList.forEach { path ->
-                    if (path.size > 2) {
-                        PathOverlay(
-                            coords = path.map { position ->
-                                LatLng(
-                                    position.latitude,
-                                    position.longitude,
-                                )
-                            },
-                            color = WalkieColor.Primary,
-                            width = 12.dp,
-                            outlineWidth = 0.dp,
-                        )
+                DrawPath(it.runningData.runningPositionList)
+            }
+
+            // 러닝 종료 후 그림
+            state.runningFinishState.getDataOrNull()?.let { finData ->
+                // 경로
+                DrawPath(finData.runningPositionList)
+            }
+
+            state.selectedImage.getDataOrNull()?.let { uri ->
+                cameraPositionState.contentBounds?.let { ll ->
+                    val imageOverlay = OverlayImage.fromBitmap(
+                        if (Build.VERSION.SDK_INT >= 28) {
+                            ImageDecoder.decodeBitmap(
+                                ImageDecoder.createSource(
+                                    LocalContext.current.contentResolver,
+                                    uri,
+                                ),
+                            )
+                        } else {
+                            MediaStore.Images.Media.getBitmap(
+                                LocalContext.current.contentResolver,
+                                uri,
+                            )
+                        },
+                    )
+                    var bounds = ll
+                    val width = imageOverlay.getIntrinsicWidth(LocalContext.current)
+                    val height = imageOverlay.getIntrinsicHeight(LocalContext.current)
+
+                    if (width != 0 && height != 0) {
+                        // TODO 비율 맞춰서 사진 확장
+                        // TODO 백그라운드
+                        val n = ll.northLatitude
+                        val s = ll.southLatitude
+                        val e = ll.eastLongitude
+                        val w = ll.westLongitude
+                        val imageRatio = height / width.toDouble()
+                        val mapRatio = (n - s) / (e - w)
+                        if (imageRatio > mapRatio) { // 높이가 높은 사진
+                            val h = n - s
+                            val center = (n + s) / 2
+                            val weight = ((h / 2) * (imageRatio / mapRatio))
+                            bounds = LatLngBounds(
+                                LatLng(center - weight, (w + e) / 2 - ((e - w) / 2) * 1.2),
+                                LatLng(center + weight, (w + e) / 2 + ((e - w) / 2) * 1.2),
+                            )
+
+                            Log.d(
+                                "imageRatio",
+                                "$imageRatio ,${
+                                    (
+                                        bounds.northLatitude - bounds.southLatitude
+                                        ) / (bounds.eastLongitude - bounds.westLongitude)
+                                }",
+                            )
+                        } else {
+                            val wi = e - w
+                            val center = (e + w) / 2
+                            val weight = ((wi / 2) * ((mapRatio / imageRatio)))
+                            bounds = LatLngBounds(
+                                LatLng(s, center - weight * 1.2),
+                                LatLng(n, center + weight * 1.2),
+                            )
+                        }
                     }
+
+                    GroundOverlay(
+                        bounds = bounds,
+                        image = imageOverlay,
+                    )
                 }
             }
-        }
+        } // End Of NaverMap
+
+        // Out of NaverMap
         // 편집 중
         state.editState.getDataOrNull()?.let { editState ->
-            // 탑 앱바
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.TopCenter)
-                    .background(Color.White)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Icon(
-                    Icons.Default.Close,
-                    "close",
-                    modifier = Modifier.clickable { onEditClose() },
-                )
-                Text("이미지", style = WalkieTypography.SubTitle)
-                Icon(
-                    Icons.Outlined.PhotoCamera,
-                    "camera",
-                    modifier = Modifier.clickable {
-                        /* TODO */
-                    },
-                )
+            if (editState) {
+                // 탑 앱바
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.TopCenter)
+                        .background(Color.White)
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Icon(
+                        Icons.Default.Close,
+                        "close",
+                        modifier = Modifier.clickable { onEditClose() },
+                    )
+                    Text("이미지", style = WalkieTypography.SubTitle)
+                    Icon(
+                        Icons.Outlined.PhotoCamera,
+                        "camera",
+                        modifier = Modifier.clickable {
+                            /* TODO */
+                        },
+                    )
+                }
             }
         }
 
         // 러닝 종료 시
         state.runningFinishState.getDataOrNull()?.let { finData ->
-            state.editState.getDataOrNull() ?: kotlin.run {
+            if (state.editState.getDataOrNull() != true) {
                 Text(
                     text = "편집",
                     style = WalkieTypography.SubTitle,
-                    modifier = Modifier.clickable { onEditOpen() }.padding(8.dp)
+                    modifier = Modifier
+                        .clickable { onEditOpen() }
+                        .padding(8.dp)
                         .clip(RoundedCornerShape(8.dp))
-                        .background(Color.White).padding(8.dp)
+                        .background(Color.White)
+                        .padding(8.dp)
                         .align(Alignment.TopEnd),
                 )
             }
@@ -312,7 +447,7 @@ fun RunningMapScreen(
                 }
             }
         } ?: run {
-            // 러닝 중
+            // 러닝 중 지도 위 아이콘 및 정보
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -375,8 +510,9 @@ fun RunningInfoScreen(
     state: RunningScreenState,
     modifier: Modifier = Modifier,
     onSelectImage: (Uri) -> Unit,
+    scope: CoroutineScope = rememberCoroutineScope(),
 ) {
-    state.editState.getDataOrNull()?.let { _ ->
+    if (state.editState.getDataOrNull() == true) {
         GalleryGrid(
             column = 3,
             modifier = modifier
@@ -527,6 +663,7 @@ fun RunningBottomButton(
     onResumeRunning: () -> Unit,
     onFinishRunning: () -> Unit,
     onEditClose: () -> Unit,
+    onTakeSnapShot: (RunningFinishData) -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -535,98 +672,96 @@ fun RunningBottomButton(
         contentAlignment = Alignment.BottomCenter,
     ) {
         // 편집 중
-        state.editState.getDataOrNull()?.let { editState ->
-            if (editState is SelectedImage.Selected) {
-                Button(
-                    modifier = Modifier
-                        .height(50.dp)
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp),
-                    onClick = { onEditClose() },
-                    shape = RoundedCornerShape(12.dp),
-                ) {
-                    Text(
-                        "확인",
-                        style = WalkieTypography.Title,
-                    )
-                }
+        if (state.editState.getDataOrNull() == true) {
+            Button(
+                modifier = Modifier
+                    .height(50.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                onClick = { onEditClose() },
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text(
+                    "확인",
+                    style = WalkieTypography.Title,
+                )
             }
-        } ?: state.runningFinishState.getDataOrNull()?.let { finState -> // 종료 시
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(modifier = Modifier.padding(bottom = 8.dp), text = "런닝을 종료했습니다.")
-                Button(
-                    modifier = Modifier
-                        .height(50.dp)
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp),
-                    onClick = {
-                        /* TODO 저장하기 */
-                    },
-                    shape = RoundedCornerShape(12.dp),
-                ) {
-                    Text(
-                        "저장",
-                        style = WalkieTypography.Title,
-                    )
-                }
-            }
-        } ?: state.runningState.getDataOrNull()?.let { runningState -> // 러닝 시작 전
-            when (runningState) {
-                is RunningState.NotRunning -> {
+        } else {
+            state.runningFinishState.getDataOrNull()?.let { finState -> // 종료 시
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(modifier = Modifier.padding(bottom = 8.dp), text = "런닝을 종료했습니다.")
                     Button(
                         modifier = Modifier
                             .height(50.dp)
-                            .width(160.dp),
-                        onClick = onStartRunning,
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
+                        onClick = { onTakeSnapShot(finState) },
+                        shape = RoundedCornerShape(12.dp),
                     ) {
-                        Text("러닝 시작", style = WalkieTypography.Title)
+                        Text(
+                            "저장",
+                            style = WalkieTypography.Title,
+                        )
                     }
                 }
-                is RunningState.Paused -> {
-                    Row(
-                        Modifier
-                            .wrapContentSize()
-                            .border(
-                                width = 1.dp,
-                                color = WalkieColor.GrayDefault,
-                                shape = CircleShape,
-                            )
-                            .clip(CircleShape)
-                            .background(Color.White),
-                    ) {
-                        IconButton(modifier = modifier, onClick = { onResumeRunning() }) {
-                            Icon(Icons.Default.PlayArrow, contentDescription = "")
-                        }
-                        IconButton(modifier = modifier, onClick = { onFinishRunning() }) {
-                            Icon(
-                                Icons.Default.Stop,
-                                contentDescription = "",
-                                tint = WalkieColor.Primary,
-                            )
+            } ?: state.runningState.getDataOrNull()?.let { runningState -> // 러닝 시작 전
+                when (runningState) {
+                    is RunningState.NotRunning -> {
+                        Button(
+                            modifier = Modifier
+                                .height(50.dp)
+                                .width(160.dp),
+                            onClick = onStartRunning,
+                        ) {
+                            Text("러닝 시작", style = WalkieTypography.Title)
                         }
                     }
-                }
-                is RunningState.Running -> {
-                    Row(
-                        Modifier
-                            .wrapContentSize()
-                            .border(
-                                width = 1.dp,
-                                color = WalkieColor.GrayDefault,
-                                shape = CircleShape,
-                            )
-                            .clip(CircleShape)
-                            .background(Color.White),
-                    ) {
-                        IconButton(modifier = modifier, onClick = { onPauseRunning() }) {
-                            Icon(Icons.Default.Pause, contentDescription = "")
+                    is RunningState.Paused -> {
+                        Row(
+                            Modifier
+                                .wrapContentSize()
+                                .border(
+                                    width = 1.dp,
+                                    color = WalkieColor.GrayDefault,
+                                    shape = CircleShape,
+                                )
+                                .clip(CircleShape)
+                                .background(Color.White),
+                        ) {
+                            IconButton(modifier = modifier, onClick = { onResumeRunning() }) {
+                                Icon(Icons.Default.PlayArrow, contentDescription = "")
+                            }
+                            IconButton(modifier = modifier, onClick = { onFinishRunning() }) {
+                                Icon(
+                                    Icons.Default.Stop,
+                                    contentDescription = "",
+                                    tint = WalkieColor.Primary,
+                                )
+                            }
                         }
-                        IconButton(modifier = modifier, onClick = { onFinishRunning() }) {
-                            Icon(
-                                Icons.Default.Stop,
-                                contentDescription = "",
-                                tint = WalkieColor.Primary,
-                            )
+                    }
+                    is RunningState.Running -> {
+                        Row(
+                            Modifier
+                                .wrapContentSize()
+                                .border(
+                                    width = 1.dp,
+                                    color = WalkieColor.GrayDefault,
+                                    shape = CircleShape,
+                                )
+                                .clip(CircleShape)
+                                .background(Color.White),
+                        ) {
+                            IconButton(modifier = modifier, onClick = { onPauseRunning() }) {
+                                Icon(Icons.Default.Pause, contentDescription = "")
+                            }
+                            IconButton(modifier = modifier, onClick = { onFinishRunning() }) {
+                                Icon(
+                                    Icons.Default.Stop,
+                                    contentDescription = "",
+                                    tint = WalkieColor.Primary,
+                                )
+                            }
                         }
                     }
                 }
@@ -649,6 +784,26 @@ fun rememberCustomLocationSource(): LocationSource {
             override fun deactivate() {
                 listener = null
             }
+        }
+    }
+}
+
+@Composable
+@NaverMapComposable
+fun DrawPath(paths: List<List<com.whyranoid.runningdata.model.RunningPosition>>) {
+    paths.forEach { path ->
+        if (path.size > 2) {
+            PathOverlay(
+                coords = path.map { position ->
+                    LatLng(
+                        position.latitude,
+                        position.longitude,
+                    )
+                },
+                color = WalkieColor.Primary,
+                width = 8.dp,
+                outlineWidth = 0.dp,
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/util/converters.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/converters.kt
@@ -1,0 +1,31 @@
+package com.whyranoid.presentation.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Base64
+import java.io.ByteArrayOutputStream
+
+object BitmapConverter {
+    fun stringToBitmap(encodedString: String?): Bitmap? {
+        return try {
+            val encodeByte: ByteArray = Base64.decode(encodedString, Base64.DEFAULT)
+            BitmapFactory.decodeByteArray(encodeByte, 0, encodeByte.size)
+        } catch (e: Exception) {
+            e.message
+            null
+        }
+    }
+
+    fun bitmapToString(bitmap: Bitmap): String {
+        val baos = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 70, baos)
+        val bytes: ByteArray = baos.toByteArray()
+        return Base64.encodeToString(bytes, Base64.DEFAULT)
+    }
+
+    fun bitmapToByteArray(bitmap: Bitmap): ByteArray {
+        val baos = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 70, baos)
+        return baos.toByteArray()
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/util/extensions.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/extensions.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.presentation.util
 
+import android.content.Context
 import kotlin.math.min
 import kotlin.random.Random
 
@@ -28,4 +29,20 @@ fun Int.toRunningTime(): String {
 
 fun Double.toPace(): String {
     return "%.1f".format(this).replace('.', '`') + "``"
+}
+
+fun Int.dpToPx(context: Context): Int {
+    val scale: Float = context.resources.displayMetrics.density
+    return (this * scale + 0.5f).toInt()
+}
+
+fun Int.pxToDp(context: Context): Int {
+    val scale: Float = context.resources.displayMetrics.density
+    val mul = when (scale) {
+        1.0f -> 4.0f
+        1.5f -> 8 / 3.0f
+        2.0f -> 2.0f
+        else -> 1.0f
+    }
+    return (this / (scale * mul)).toInt()
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningEditViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningEditViewModel.kt
@@ -1,0 +1,132 @@
+package com.whyranoid.presentation.viewmodel
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.core.os.bundleOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.cachedIn
+import com.whyranoid.presentation.viewmodel.GalleryPagingSource.Companion.PAGING_SIZE
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class RunningEditViewModel : ViewModel() {
+    private val _selectedState: MutableStateFlow<Uri?> = MutableStateFlow(null)
+    val selectedState: StateFlow<Uri?> get() = _selectedState.asStateFlow()
+
+    private fun galleryPagingItems(context: Context) =
+        Pager(
+            config = PagingConfig(
+                pageSize = PAGING_SIZE,
+            ),
+            pagingSourceFactory = {
+                GalleryPagingSource(context)
+            },
+        ).flow
+
+    fun getImages(context: Context): Flow<PagingData<Uri>> =
+        galleryPagingItems(context).cachedIn(viewModelScope)
+
+    fun select(uri: Uri) {
+        _selectedState.value = uri
+    }
+}
+
+class GalleryPagingSource(private val context: Context) : PagingSource<Int, Uri>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Uri> {
+        return try {
+            val currentPage = params.key ?: 0
+            val offset = currentPage * PAGING_SIZE
+
+            val imageUris = getImageUris(context.contentResolver, offset, PAGING_SIZE)
+
+            LoadResult.Page(
+                data = imageUris,
+                prevKey = if (currentPage == 0) null else currentPage - 1,
+                nextKey = if (imageUris.isNotEmpty()) currentPage + 1 else null,
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    private fun getImageUris(contentResolver: ContentResolver, offset: Int, limit: Int): List<Uri> {
+        val imageUris = mutableListOf<Uri>()
+        val projection = arrayOf(
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.TITLE,
+            MediaStore.Images.Media.DISPLAY_NAME,
+            MediaStore.Images.Media.MIME_TYPE,
+            MediaStore.Images.Media.DATE_TAKEN,
+            MediaStore.Images.Media.BUCKET_DISPLAY_NAME,
+            MediaStore.Images.Media.SIZE,
+            MediaStore.Images.Media.WIDTH,
+            MediaStore.Images.Media.HEIGHT,
+        )
+        val selection =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                MediaStore.Images.Media.SIZE + " > 0"
+            } else {
+                null
+            }
+
+        val cursor: Cursor? = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val sortOrder = "${MediaStore.Images.Media.DATE_TAKEN} DESC LIMIT $limit OFFSET $offset"
+            contentResolver.query(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                projection,
+                selection,
+                null,
+                sortOrder,
+            )
+        } else {
+            contentResolver.query(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                projection,
+                bundleOf(
+                    ContentResolver.QUERY_ARG_OFFSET to offset,
+                    ContentResolver.QUERY_ARG_LIMIT to limit,
+                    ContentResolver.QUERY_ARG_SORT_COLUMNS to arrayOf(MediaStore.Images.Media.DATE_TAKEN),
+                    ContentResolver.QUERY_ARG_SORT_DIRECTION to ContentResolver.QUERY_SORT_DIRECTION_DESCENDING,
+                    ContentResolver.QUERY_ARG_SQL_SELECTION to selection,
+                ),
+                null,
+            )
+        }
+        cursor?.use {
+            val idColumn = it.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            while (it.moveToNext()) {
+                val imageId = it.getLong(idColumn)
+                val contentUri = Uri.withAppendedPath(
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    imageId.toString(),
+                )
+                imageUris.add(contentUri)
+            }
+        }
+        return imageUris
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Uri>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    companion object {
+        const val PAGING_SIZE = 20
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
@@ -34,6 +34,7 @@ data class RunningScreenState(
     val trackingModeState: UiState<TrackingMode> = UiState.Idle,
     val runningFinishState: UiState<RunningFinishData> = UiState.Idle,
     val userLocationState: UiState<UserLocation> = UiState.Idle,
+    val editState: UiState<Unit> = UiState.Idle,
 )
 
 class RunningViewModel(
@@ -156,6 +157,25 @@ class RunningViewModel(
                 )
             }
         }
+    }
+
+    fun openEdit() {
+        intent {
+            reduce {
+                state.copy(editState = UiState.Success(Unit))
+            }
+        }
+    }
+
+    fun closeEdit() {
+        intent {
+            reduce {
+                state.copy(editState = UiState.Idle)
+            }
+        }
+    }
+
+    fun editBackground() {
     }
 
     companion object {

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
@@ -14,6 +14,7 @@ import com.whyranoid.domain.usecase.running.RunningStartUseCase
 import com.whyranoid.presentation.model.UiState
 import com.whyranoid.presentation.model.running.RunningFollower
 import com.whyranoid.presentation.model.running.RunningInfo
+import com.whyranoid.presentation.model.running.SelectedImage
 import com.whyranoid.presentation.model.running.TrackingMode
 import com.whyranoid.runningdata.RunningDataManager
 import com.whyranoid.runningdata.model.RunningFinishData
@@ -35,7 +36,7 @@ data class RunningScreenState(
     val trackingModeState: UiState<TrackingMode> = UiState.Idle,
     val runningFinishState: UiState<RunningFinishData> = UiState.Idle,
     val userLocationState: UiState<UserLocation> = UiState.Idle,
-    val editState: UiState<Uri?> = UiState.Idle,
+    val editState: UiState<SelectedImage> = UiState.Idle,
 )
 
 class RunningViewModel(
@@ -163,7 +164,7 @@ class RunningViewModel(
     fun openEdit() {
         intent {
             reduce {
-                state.copy(editState = UiState.Success(null))
+                state.copy(editState = UiState.Success(SelectedImage.None))
             }
         }
     }
@@ -179,7 +180,7 @@ class RunningViewModel(
     fun selectImage(uri: Uri) {
         intent {
             reduce {
-                state.copy(editState = UiState.Success(uri))
+                state.copy(editState = UiState.Success(SelectedImage.Selected(uri)))
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/RunningViewModel.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.presentation.viewmodel
 
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -34,7 +35,7 @@ data class RunningScreenState(
     val trackingModeState: UiState<TrackingMode> = UiState.Idle,
     val runningFinishState: UiState<RunningFinishData> = UiState.Idle,
     val userLocationState: UiState<UserLocation> = UiState.Idle,
-    val editState: UiState<Unit> = UiState.Idle,
+    val editState: UiState<Uri?> = UiState.Idle,
 )
 
 class RunningViewModel(
@@ -162,7 +163,7 @@ class RunningViewModel(
     fun openEdit() {
         intent {
             reduce {
-                state.copy(editState = UiState.Success(Unit))
+                state.copy(editState = UiState.Success(null))
             }
         }
     }
@@ -175,7 +176,12 @@ class RunningViewModel(
         }
     }
 
-    fun editBackground() {
+    fun selectImage(uri: Uri) {
+        intent {
+            reduce {
+                state.copy(editState = UiState.Success(uri))
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
## 😎 작업 내용
- 러닝 화면 구현

## 🧐 변경된 내용
- 권한 요청 및 위치, 저장소 권한 사용
- 워커를 사용해 백그라운드로 러닝 기능 구현
- 러닝 종료 후 갤러리 사진을 페이징으로 가져오고 지도위에 띄우기
- 사진과 함께 운동 기록을 데이터베이스에 저장

## 🥳 동작 화면
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/e23344c5-a778-42a1-abbb-05c53381e637"  width="300" height="720">
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/46908f06-50a9-4ced-aa18-c1045742c23b"  width="300" height="720">
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/31ca1b1a-03c5-44c9-ab18-111f3f051741"  width="300" height="720">
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/ebe6df14-a816-4d59-bef4-d094075bbdb7"  width="300" height="720">


## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음