### PR TITLE
워키TopBar 구현

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/component/bar/WalkieTopBar.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/bar/WalkieTopBar.kt
@@ -1,0 +1,39 @@
+package com.whyranoid.presentation.component.bar
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun WalkieTopBar(
+    leftContent: @Composable (() -> Unit)? = null,
+    middleContent: @Composable (() -> Unit)? = null,
+    rightContent: @Composable (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(54.dp)
+            .padding(20.dp, 13.dp),
+
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        leftContent?.let {
+            it()
+        }
+        middleContent?.let {
+            it()
+        }
+        rightContent?.let {
+            it()
+        }
+
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
@@ -1,30 +1,97 @@
 package com.whyranoid.presentation.screens
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.whyranoid.presentation.component.bar.WalkieTopBar
 import com.whyranoid.presentation.component.community.PostItem
 import com.whyranoid.presentation.component.community.RunningFollowerItem
+import com.whyranoid.presentation.theme.WalkieTypography
 
 @Composable
 fun CommunityScreen(
     navController: NavController
 ) {
 
-    LazyColumn {
+    Scaffold(
+        topBar = {
+            WalkieTopBar(
+                leftContent = {
+                    Row {
+                        Text(
+                            text = "커뮤니티",
+                            style = WalkieTypography.Title.copy(fontWeight = FontWeight(600)),
+                        )
 
-        item {
-            LazyRow {
-                repeat(10) {
-                    item { RunningFollowerItem() }
+                        Spacer(modifier = Modifier.width(7.dp))
+
+                        Icon(
+                            modifier = Modifier
+                                .clickable {
+
+                                },
+                            imageVector = Icons.Filled.KeyboardArrowDown, contentDescription = "Down Arrow"
+                        )
+                    }
+                },
+                rightContent = {
+                    Row {
+                        Icon(
+                            modifier = Modifier
+                                .clickable {
+
+                                },
+                            imageVector = Icons.Filled.Add, contentDescription = "추가 버튼"
+                        )
+
+                        Spacer(modifier = Modifier.width(16.dp))
+
+                        Icon(
+                            modifier = Modifier
+                                .clickable {
+
+                                },
+                            imageVector = Icons.Filled.Search, contentDescription = "검색 버튼"
+                        )
+                    }
+
+                },
+            )
+        },
+    ) {
+
+        LazyColumn(
+            modifier = Modifier.padding(it)
+        ) {
+
+            item {
+                LazyRow {
+                    repeat(10) {
+                        item { RunningFollowerItem() }
+                    }
                 }
             }
-        }
 
-        repeat(10) {
-            item {
-                PostItem()
+            repeat(10) {
+                item {
+                    PostItem()
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -34,6 +36,7 @@ import com.whyranoid.domain.model.challenge.ChallengePreview
 import com.whyranoid.domain.model.challenge.ChallengeType
 import com.whyranoid.presentation.component.ChallengeItem
 import com.whyranoid.presentation.component.ChallengingItem
+import com.whyranoid.presentation.component.bar.WalkieTopBar
 import com.whyranoid.presentation.reusable.WalkieCircularProgressIndicator
 import com.whyranoid.presentation.theme.ChallengeColor.getColor
 import com.whyranoid.presentation.theme.WalkieTypography
@@ -75,12 +78,46 @@ fun ChallengeMainContent(
 ) {
 
     Scaffold(
-        Modifier.padding(horizontal = 20.dp)
-    ) { paddingValues ->
+        topBar = {
+            WalkieTopBar(
+                leftContent = {
+                    Text(
+                        text = "챌린지",
+                        style = WalkieTypography.Title.copy(fontWeight = FontWeight(600)),
+                    )
+                },
+                rightContent = {
+                    Row {
+                        Icon(
+                            modifier = Modifier
+                                .clickable {
 
+                                },
+                            imageVector = Icons.Filled.Search, contentDescription = "검색 버튼"
+                        )
+
+                        Spacer(modifier = Modifier.width(16.dp))
+
+                        Icon(
+                            modifier = Modifier
+                                .clickable {
+
+                                },
+                            imageVector = Icons.Filled.Menu, contentDescription = "메뉴 버튼"
+                        )
+                    }
+
+                },
+            )
+        },
+    ) { paddingValues ->
         val pagerState = rememberPagerState()
 
-        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(horizontal = 20.dp)
+        ) {
 
             item {
                 Spacer(modifier = Modifier.height(10.dp))


### PR DESCRIPTION
## 😎 작업 내용
- 재활용 가능한 WalkieTopBar 구현

## 🧐 변경된 내용
- 변경된 내용을 작성해주세요.

## 🥳 동작 화면
- 커뮤니티 메인

<img width="424" alt="Screenshot 2023-09-12 at 3 12 25 PM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/2eaaa039-bb2f-4250-97cc-b0059b3d8295">

- 챌린지 메인

<img width="434" alt="Screenshot 2023-09-12 at 3 12 55 PM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/24985ec9-f1fe-443a-98ae-bc364fc3c18f">


## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 중앙에만 아이템을 배정하고 싶을 경우 leftContent, rightContent는 Spacer와 같은 빈 컴포저블로 위치를 할당시키면 됨.