### PR TITLE
피드 사진 가져오기 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 26
         targetSdk = 33
         versionCode = 1
-        versionName = "1.0.4"
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 26
         targetSdk = 33
         versionCode = 1
-        versionName = "1.0.5"
+        versionName = "1.0.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -91,7 +91,7 @@ val viewModelModule = module {
     single { ChallengeMainViewModel(get(), get(), get()) }
     single { ChallengeDetailViewModel(get()) }
     single { ChallengeExitViewModel(get()) }
-    single { UserPageViewModel(get(), get(), get(), get(), get(), get()) }
+    factory { UserPageViewModel(get(), get(), get(), get(), get(), get()) }
     factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
     factory { RunningEditViewModel() }
     factory { SplashViewModel(get()) }

--- a/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
@@ -49,7 +49,6 @@ class PostDataSourceImpl(private val postService: PostService) : PostDataSource 
         return getMyPostPreviews(uid).onSuccess { posts ->
             posts.filter { postPreview ->
                 val date = Date(postPreview.date)
-                Log.d("TODOREMOVE", "${date.year}, ${date.month + 1}, ${date.date}")
                 date.month + 1 == month && year == date.year && day == date.date
             }
         }

--- a/data/src/main/java/com/whyranoid/data/model/post/PostResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/post/PostResponse.kt
@@ -26,7 +26,7 @@ data class PostResponse(
             id = this.poster.uid,
             isLiked = this.liked,
             likers = this.likers.map { it.toUser() },
-            imageUrl = this.photo,
+            imageUrl = this.photo.toRealUrl(),
             date = dateFormatter.parse(this.date.replace("T", " ")).time,
             textVisibleState = TextVisibleState.values()[this.colorMode.toInt()],
             distanceText = destructedHistoryContent[2],
@@ -34,5 +34,16 @@ data class PostResponse(
             paceText = destructedHistoryContent[4],
             address = destructedHistoryContent[1],
         )
+    }
+
+    private fun String.toRealUrl(): String {
+        return (FIREBASE_STORAGE_URL + this.split(DIVIDER)[1] + MEDIA_TYPE).also { println("test\n$it") }
+    }
+
+    companion object {
+        const val DIVIDER = "/post/"
+        const val FIREBASE_STORAGE_URL =
+            "https://firebasestorage.googleapis.com/v0/b/walkie-5bfb3.appspot.com/o/post%2F"
+        const val MEDIA_TYPE = "?alt=media"
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -75,7 +75,7 @@ fun MyPageScreen(
 ) {
     val viewModel = koinViewModel<UserPageViewModel>()
 
-    LaunchedEffect(true) {
+    LaunchedEffect(Unit) {
         uid?.let {
             viewModel.getUserDetail(uid)
             viewModel.getUserBadges(uid)
@@ -110,11 +110,11 @@ fun MyPageScreen(
 @Composable
 fun MyPageContent(
     state: UserPageState,
-    onPostPreviewClicked: (id: Long) -> Unit = {}, // TODO 아이탬 클릭시 이벤트 처리
-    onPostCreateClicked: () -> Unit = {}, // TODO 아이탬 생성 이벤트 처리
-    onProfileEditClicked: () -> Unit = {}, // TODO
-    onSettingsClicked: () -> Unit = {}, // TODO
-    onLogoutClicked: () -> Unit = {}, // TODO
+    onPostPreviewClicked: (id: Long) -> Unit = {},
+    onPostCreateClicked: () -> Unit = {},
+    onProfileEditClicked: () -> Unit = {},
+    onSettingsClicked: () -> Unit = {},
+    onLogoutClicked: () -> Unit = {},
     onDateClicked: (LocalDate) -> Unit = {},
 ) {
     Scaffold(

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.whyranoid.domain.model.post.PostPreview
 import com.whyranoid.domain.model.post.TextVisibleState
-import com.whyranoid.domain.model.user.User
 import com.whyranoid.presentation.reusable.NonLazyGrid
 import com.whyranoid.presentation.theme.WalkieColor
 import java.text.SimpleDateFormat
@@ -101,7 +100,7 @@ fun PostImagePreview(
         },
     ) {
         AsyncImage(
-            model = User.DUMMY.imageUrl, // TODO REMOVE postPreview.imageUrl,
+            model = postPreview.imageUrl,
             contentDescription = "postPreview Image",
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## 😎 작업 내용
- 피드 사진 가져오기 구현

## 🧐 변경된 내용
- 더미 사진 url -> 실제 사진 url 로 변경 #54 
- 사진 바로 안가져와지고 캘린더에 적용 안되던 버그 수정

## 🥳 동작 화면
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/2a11cf7e-c29e-44a1-8085-ee38f9cf4d92" width="300" height="720">


## 🤯 이슈 번호
- closed #54 

## 🥲 비고
- 비고 없음