### PR TITLE
챌린지 메인화면 아이템 패딩 조절

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -119,13 +120,14 @@ fun ChallengeMainContent(
         LazyColumn(
             modifier = Modifier
                 .padding(paddingValues)
-                .padding(horizontal = 20.dp)
+//                .padding(horizontal = 20.dp)
         ) {
 
             item {
                 Spacer(modifier = Modifier.height(10.dp))
 
                 Text(
+                    modifier = Modifier.padding(horizontal = 20.dp),
                     text = "신규",
                     fontSize = 16.sp,
                     color = Color.Black,
@@ -138,7 +140,8 @@ fun ChallengeMainContent(
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(13.dp)
+                    horizontalArrangement = Arrangement.spacedBy(13.dp),
+                    contentPadding = PaddingValues(20.dp)
                 ) {
 
                     state.newChallengePreviewsState.getDataOrNull()?.let { newChallengePreviews ->
@@ -165,6 +168,7 @@ fun ChallengeMainContent(
 
             item {
                 Text(
+                    modifier = Modifier.padding(horizontal = 20.dp),
                     text = "도전중인 챌린지",
                     fontSize = 20.sp,
                     color = Color.Black,
@@ -174,7 +178,9 @@ fun ChallengeMainContent(
             }
 
             item {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally) {
 
                     state.challengingPreviewsState.getDataOrNull()?.let { challengingPreviews ->
                         challengingPreviews.take(4).forEach {
@@ -208,6 +214,7 @@ fun ChallengeMainContent(
 
             item {
                 Text(
+                    modifier = Modifier.padding(horizontal = 20.dp),
                     text = "다른 챌린지도 도전해보세요!",
                     fontSize = 20.sp,
                     color = Color.Black,
@@ -218,6 +225,7 @@ fun ChallengeMainContent(
 
             item {
                 Text(
+                    modifier = Modifier.padding(horizontal = 20.dp),
                     text = "인기 챌린지",
                     fontSize = 16.sp,
                     color = Color.Black,
@@ -230,7 +238,8 @@ fun ChallengeMainContent(
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(13.dp)
+                    horizontalArrangement = Arrangement.spacedBy(13.dp),
+                    contentPadding = PaddingValues(20.dp)
                 ) {
                     state.newChallengePreviewsState.getDataOrNull()?.let { newChallengePreviews ->
                         newChallengePreviews.chunkedList(3).forEach { list ->
@@ -262,6 +271,7 @@ fun ChallengeMainContent(
 
             item {
                 Text(
+                    modifier = Modifier.padding(horizontal = 20.dp),
                     text = "유형별 챌린지",
                     fontSize = 16.sp,
                     color = Color.Black,
@@ -299,6 +309,7 @@ fun ChallengeMainContent(
 
                 HorizontalPager(
                     state = pagerState,
+                    modifier = Modifier.padding(horizontal = 20.dp),
                 ) {
 
                     state.typedChallengePreviewsState.getDataOrNull()


### PR DESCRIPTION
## 😎 작업 내용
- 챌린지 메인화면 아이템 패딩 조절

## 🧐 변경된 내용
- 변경된 내용을 작성해주세요.

## 🥳 동작 화면
<img width="422" alt="Screenshot 2023-11-30 at 1 04 42 PM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/4ae489f9-6841-4640-97d7-13561c443e89">

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음