### PR TITLE
유저 페이지 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 26
         targetSdk = 33
         versionCode = 1
-        versionName = "1.0.6"
+        versionName = "1.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetUserDetailUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetUserDetailUseCase.kt
@@ -7,6 +7,9 @@ class GetUserDetailUseCase(
     private val userRepository: UserRepository,
 ) {
     suspend operator fun invoke(uid: Long): Result<UserDetail> {
-        return userRepository.getUserDetail(uid)
+        return kotlin.runCatching {
+            val user = userRepository.getUser(uid).getOrThrow()
+            UserDetail(user, 0, 0, 0, true)
+        }
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/community/GetSearchedUserUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/community/GetSearchedUserUseCase.kt
@@ -17,6 +17,8 @@ class GetSearchedUserUseCase(
                     user,
                     followingList.contains(user),
                 )
+            }.filter {
+                it.user.uid != uid
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -32,6 +32,7 @@ import com.whyranoid.presentation.screens.challenge.ChallengeExitScreen
 import com.whyranoid.presentation.screens.challenge.ChallengeMainScreen
 import com.whyranoid.presentation.screens.community.SearchFriendScreen
 import com.whyranoid.presentation.screens.mypage.MyPageScreen
+import com.whyranoid.presentation.screens.mypage.UserPageScreen
 import com.whyranoid.presentation.screens.mypage.addpost.AddPostScreen
 import com.whyranoid.presentation.screens.mypage.editprofile.EditProfileScreen
 import com.whyranoid.presentation.screens.running.RunningScreen
@@ -40,7 +41,6 @@ import com.whyranoid.presentation.screens.splash.SplashScreen
 import com.whyranoid.presentation.theme.WalkieColor
 import com.whyranoid.presentation.viewmodel.SplashState
 import com.whyranoid.presentation.viewmodel.SplashViewModel
-import org.koin.androidx.compose.get
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -136,6 +136,10 @@ fun AppScreenContent(
                 MyPageScreen(navController)
             }
 
+            composable(Screen.MyPage.route) {
+                MyPageScreen(navController)
+            }
+
             composable(Screen.AddPostScreen.route) {
                 AddPostScreen(navController = navController)
             }
@@ -169,6 +173,17 @@ fun AppScreenContent(
                 val arguments = requireNotNull(backStackEntry.arguments)
                 val challengeId = arguments.getLong("challengeId")
                 ChallengeCompleteScreen(navController, challengeId)
+            }
+
+            composable(
+                Screen.UserPageScreen.route,
+                Screen.UserPageScreen.arguments,
+            ) { backStackEntry ->
+                val arguments = requireNotNull(backStackEntry.arguments)
+                val uid = arguments.getLong(Screen.UID_ARGUMENT)
+                val nickname = requireNotNull(arguments.getString(Screen.NICKNAME_ARGUMENT))
+                val isFollowing = arguments.getBoolean(Screen.NICKNAME_ARGUMENT)
+                UserPageScreen(navController, uid, nickname, isFollowing)
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
@@ -87,7 +87,20 @@ sealed class Screen(
         ),
     )
 
+    object UserPageScreen : Screen(
+        route = "userPage/{$UID_ARGUMENT}/{$NICKNAME_ARGUMENT}/{$IS_FOLLOWING_ARGUMENT}",
+        arguments = listOf(
+            navArgument(UID_ARGUMENT) { type = NavType.LongType },
+            navArgument(NICKNAME_ARGUMENT) { type = NavType.StringType },
+            navArgument(IS_FOLLOWING_ARGUMENT) { type = NavType.BoolType },
+        ),
+    )
+
     companion object {
         val bottomNavigationItems = listOf(Running, Community, ChallengeMainScreen, MyPage)
+
+        const val UID_ARGUMENT = "uid"
+        const val NICKNAME_ARGUMENT = "nickname"
+        const val IS_FOLLOWING_ARGUMENT = "isFollowing"
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/community/SearchFriendScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/community/SearchFriendScreen.kt
@@ -155,6 +155,9 @@ fun SearchFriendScreen(
                         onClickUnFollow = { user ->
                             viewModel.unFollow(user)
                         },
+                        onClickItem = { user ->
+                            navController.navigate("userPage/${user.uid}/${user.nickname}/${item.isFollowing}")
+                        },
                     )
                     Spacer(modifier = Modifier.height(5.dp))
                 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/community/SearchedFriendItem.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/community/SearchedFriendItem.kt
@@ -30,11 +30,12 @@ fun SearchedFriendItem(
     userWithFollowingState: UserWithFollowingState,
     onClickFollow: (User) -> Unit = {},
     onClickUnFollow: (User) -> Unit = {},
+    onClickItem: (User) -> Unit = {},
 ) {
     var isFollowing by remember { mutableStateOf(userWithFollowingState.isFollowing) }
 
     Row(
-        modifier = modifier,
+        modifier = modifier.clickable { onClickItem(userWithFollowingState.user) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/UserPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/UserPageScreen.kt
@@ -1,0 +1,33 @@
+package com.whyranoid.presentation.screens.mypage
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavController
+import com.whyranoid.presentation.viewmodel.UserPageViewModel
+import org.koin.androidx.compose.koinViewModel
+import org.orbitmvi.orbit.compose.collectAsState
+
+@Composable
+fun UserPageScreen(
+    navController: NavController,
+    uid: Long,
+    nickname: String,
+    isFollowing: Boolean,
+) {
+    val viewModel = koinViewModel<UserPageViewModel>()
+
+    LaunchedEffect(Unit) {
+        viewModel.getUserDetail(uid, isFollowing)
+        viewModel.getUserBadges(uid)
+        viewModel.getUserPostPreviews(uid)
+    }
+
+    val state by viewModel.collectAsState()
+
+    UserPageContent(
+        nickname,
+        state,
+        onDateClicked = viewModel::selectDate,
+    )
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
@@ -40,6 +40,7 @@ import java.util.*
 
 @Composable
 fun PostPage(
+    isMyPage: Boolean = true,
     postPreviews: List<PostPreview>,
     onPostPreviewClicked: (id: Long) -> Unit,
     onPostCreateClicked: () -> Unit,
@@ -54,7 +55,7 @@ fun PostPage(
                 postPreview = postPreviews[index],
                 onPostPreviewClicked = onPostPreviewClicked,
             )
-        } else {
+        } else if (isMyPage) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/UserViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/UserViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.whyranoid.domain.model.challenge.Badge
 import com.whyranoid.domain.model.post.PostPreview
+import com.whyranoid.domain.model.user.User
 import com.whyranoid.domain.model.user.UserDetail
 import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.usecase.GetPostUseCase
@@ -40,14 +41,14 @@ class UserPageViewModel(
 
     override val container = container<UserPageState, UserPageSideEffect>(UserPageState())
 
-    fun getUserDetail(uid: Long) = intent {
+    fun getUserDetail(uid: Long, isFollowing: Boolean) = intent {
         reduce {
             state.copy(userDetailState = UiState.Loading)
         }
         getUserDetailUseCase(uid).onSuccess { userDetail ->
             reduce {
                 state.copy(
-                    userDetailState = UiState.Success(userDetail),
+                    userDetailState = UiState.Success(userDetail.copy(isFollowing = isFollowing)),
                 )
             }
         }.onFailure {
@@ -82,6 +83,16 @@ class UserPageViewModel(
             reduce {
                 state.copy(
                     userPostPreviewsState = UiState.Success(userPostPreviews),
+                    userDetailState = UiState.Success(
+                        UserDetail(
+                            state.userDetailState.getDataOrNull()?.user ?: User.DUMMY,
+                            state.userDetailState.getDataOrNull()?.postCount
+                                ?: userPostPreviews.size,
+                            state.userDetailState.getDataOrNull()?.followerCount ?: 0,
+                            state.userDetailState.getDataOrNull()?.followingCount ?: 0,
+                            state.userDetailState.getDataOrNull()?.isFollowing ?: false,
+                        ),
+                    ),
                 )
             }
         }.onFailure {


### PR DESCRIPTION
## 😎 작업 내용
- 유저페이지 구현

## 🧐 변경된 내용
- 친구 검색에서 사용자 본인 중복 제거
- 유저 프로필 클릭 시 유저 페이지로 이동

## 🥳 동작 화면
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/7d554689-ee5e-4c93-ba5f-2c13a5df1b7e" width="360">


## 🤯 이슈 번호
- #60

## 🥲 비고
- uid 기반 User데이터 가져오기(Profile Image Url, Badge 등)는 아직 미구현, 다음주 중 구현 예정