### PR TITLE
좋아요 기능 구현, Reponse(retrofit)에서 결과를 가져오는 확장함수 구현

### DIFF
--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -11,6 +11,9 @@ import com.whyranoid.data.datasource.OtherUserPagingSource
 import com.whyranoid.data.datasource.UserDataSourceImpl
 import com.whyranoid.data.datasource.account.AccountDataSourceImpl
 import com.whyranoid.data.datasource.account.AccountService
+import com.whyranoid.data.datasource.community.CommunityDataSource
+import com.whyranoid.data.datasource.community.CommunityDataSourceImpl
+import com.whyranoid.data.datasource.community.CommunityService
 import com.whyranoid.data.datasource.follow.FollowDataSourceImpl
 import com.whyranoid.data.datasource.follow.FollowService
 import com.whyranoid.data.datasource.post.PostDataSourceImpl
@@ -19,6 +22,7 @@ import com.whyranoid.data.datasource.running.RunningControlDataSourceImpl
 import com.whyranoid.data.datasource.running.RunningService
 import com.whyranoid.data.repository.AccountRepositoryImpl
 import com.whyranoid.data.repository.ChallengeRepositoryImpl
+import com.whyranoid.data.repository.CommunityRepositoryImpl
 import com.whyranoid.data.repository.FollowRepositoryImpl
 import com.whyranoid.data.repository.GpsRepositoryImpl
 import com.whyranoid.data.repository.NetworkRepositoryImpl
@@ -35,6 +39,7 @@ import com.whyranoid.domain.datasource.RunningControlDataSource
 import com.whyranoid.domain.datasource.UserDataSource
 import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.repository.ChallengeRepository
+import com.whyranoid.domain.repository.CommunityRepository
 import com.whyranoid.domain.repository.FollowRepository
 import com.whyranoid.domain.repository.GpsRepository
 import com.whyranoid.domain.repository.NetworkRepository
@@ -53,6 +58,7 @@ import com.whyranoid.domain.usecase.GetPostUseCase
 import com.whyranoid.domain.usecase.GetUserBadgesUseCase
 import com.whyranoid.domain.usecase.GetUserDetailUseCase
 import com.whyranoid.domain.usecase.GetUserPostPreviewsUseCase
+import com.whyranoid.domain.usecase.LikePostUseCase
 import com.whyranoid.domain.usecase.SignOutUseCase
 import com.whyranoid.domain.usecase.UploadPostUseCase
 import com.whyranoid.domain.usecase.broadcast.AddGpsListener
@@ -106,7 +112,7 @@ val viewModelModule = module {
     factory { AddPostViewModel(get()) }
     factory { SearchFriendViewModel(get(), get(), get()) }
     factory { DialogViewModel(get(), get(), get(), get(), get(), get()) }
-    factory { CommunityScreenViewModel(get(), get()) }
+    factory { CommunityScreenViewModel(get(), get(), get()) }
 }
 
 val repositoryModule = module {
@@ -120,6 +126,7 @@ val repositoryModule = module {
     single<NetworkRepository> { NetworkRepositoryImpl(get()) }
     single<GpsRepository> { GpsRepositoryImpl(get()) }
     single<OtherUserRepository> { OtherUserRepositoryImpl(OtherUserPagingSource()) }
+    single<CommunityRepository> { CommunityRepositoryImpl(get()) }
 }
 
 val dataSourceModule = module {
@@ -129,6 +136,7 @@ val dataSourceModule = module {
     single<AccountDataSource> { AccountDataSourceImpl(get()) }
     single<FollowDataSource> { FollowDataSourceImpl(get()) }
     single<RunningControlDataSource> { RunningControlDataSourceImpl(get()) }
+    single<CommunityDataSource> { CommunityDataSourceImpl(get()) }
 }
 
 val useCaseModule = module {
@@ -157,6 +165,7 @@ val useCaseModule = module {
     single { UnFollowUseCase(get(), get()) }
     single { GetMyFollowingUseCase(get(), get()) }
     single { GetFollowingsPostsUseCase(get(), get()) }
+    single { LikePostUseCase(get(), get()) }
 }
 
 val databaseModule = module {
@@ -222,4 +231,6 @@ val networkModule = module {
     single { get<Retrofit>().create(PostService::class.java) }
 
     single { get<Retrofit>().create(RunningService::class.java) }
+
+    single { get<Retrofit>().create(CommunityService::class.java) }
 }

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -25,6 +25,8 @@ object API {
 
     const val SEARCH = "api/community/search-nickname"
 
+    const val SEND_LIKE = "api/community/send-like"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/Utils.kt
+++ b/data/src/main/java/com/whyranoid/data/Utils.kt
@@ -1,0 +1,12 @@
+package com.whyranoid.data
+
+import retrofit2.Response
+
+fun <T, R> Response<T>.getResult(transform: (T) -> R): R {
+    if (this.isSuccessful.not())
+        throw Exception(this.errorBody().toString())
+    else if (this.body() == null)
+        throw Exception(this.message())
+
+    return requireNotNull(this.body()?.let(transform) ?: throw Exception("empty response"))
+}

--- a/data/src/main/java/com/whyranoid/data/datasource/community/CommunityDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/community/CommunityDataSource.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.data.datasource.community
+
+interface CommunityDataSource {
+
+    suspend fun likePost(postId: Long, likerId: Long): Result<Long>
+}

--- a/data/src/main/java/com/whyranoid/data/datasource/community/CommunityDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/community/CommunityDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.whyranoid.data.datasource.community
+
+import com.whyranoid.data.getResult
+import com.whyranoid.data.model.community.request.PostLikeRequest
+
+class CommunityDataSourceImpl(
+    private val service: CommunityService
+) : CommunityDataSource {
+    override suspend fun likePost(postId: Long, likerId: Long): Result<Long> {
+
+        return kotlin.runCatching {
+            val request = PostLikeRequest(likerId, postId)
+            val response = service.likePost(request)
+
+            response.getResult {
+                it.likerCount
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/datasource/community/CommunityService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/community/CommunityService.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.data.datasource.community
+
+import com.whyranoid.data.API
+import com.whyranoid.data.model.community.request.PostLikeRequest
+import com.whyranoid.data.model.community.response.PostLikeResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface CommunityService {
+
+    @POST(API.SEND_LIKE)
+    suspend fun likePost(@Body postLikeRequest: PostLikeRequest): Response<PostLikeResponse>
+
+}

--- a/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
@@ -93,7 +93,7 @@ class PostDataSourceImpl(private val postService: PostService) : PostDataSource 
     override suspend fun getMyFollowingsPost(uid: Long): Result<List<Post>> {
         return kotlin.runCatching {
             val posts = requireNotNull(postService.getPosts(uid).body())
-            posts.map { it.toPost() }
+            posts.map { it.toPost(uid) }
         }
     }
 }

--- a/data/src/main/java/com/whyranoid/data/model/community/request/PostLikeRequest.kt
+++ b/data/src/main/java/com/whyranoid/data/model/community/request/PostLikeRequest.kt
@@ -1,0 +1,8 @@
+package com.whyranoid.data.model.community.request
+
+import com.google.gson.annotations.SerializedName
+
+data class PostLikeRequest(
+    @SerializedName("likerId") val likerId: Long,
+    @SerializedName("postId") val postId: Long,
+)

--- a/data/src/main/java/com/whyranoid/data/model/community/response/LikerProfile.kt
+++ b/data/src/main/java/com/whyranoid/data/model/community/response/LikerProfile.kt
@@ -1,0 +1,10 @@
+package com.whyranoid.data.model.community.response
+
+import com.google.gson.annotations.SerializedName
+
+data class LikerProfile(
+    @SerializedName("nickname") val nickname: String,
+    @SerializedName("profileImg") val profileImg: String,
+    @SerializedName("status") val status: String,
+    @SerializedName("walkieId") val walkieId: Long
+)

--- a/data/src/main/java/com/whyranoid/data/model/community/response/PostLikeResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/community/response/PostLikeResponse.kt
@@ -1,0 +1,10 @@
+package com.whyranoid.data.model.community.response
+
+import com.google.gson.annotations.SerializedName
+
+data class PostLikeResponse(
+    @SerializedName("likerCount") val likerCount: Long,
+    @SerializedName("likerId") val likerId: Long,
+    @SerializedName("likerProfiles") val likerProfiles: List<LikerProfile>,
+    @SerializedName("postId") val postId: Long
+)

--- a/data/src/main/java/com/whyranoid/data/model/post/PostResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/post/PostResponse.kt
@@ -36,13 +36,14 @@ data class PostResponse(
         )
     }
 
-    fun toPost(): Post {
+    fun toPost(myUid: Long): Post {
         return Post(
             id = this.postId,
             imageUrl = this.photo,
             likeCount = this.likers.size,
             contents = this.content,
             author = this.poster.toUser(),
+            isLiked = this.likers.firstOrNull { it.uid == myUid } != null,
             date = dateFormatter.parse(this.date.replace("T", " ")).time,
         )
     }

--- a/data/src/main/java/com/whyranoid/data/repository/CommunityRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/CommunityRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.whyranoid.data.repository
+
+import com.whyranoid.data.datasource.community.CommunityDataSource
+import com.whyranoid.domain.repository.CommunityRepository
+
+class CommunityRepositoryImpl(
+    private val communityDataSource: CommunityDataSource
+): CommunityRepository {
+    override suspend fun likePost(postId: Long, likerId: Long): Result<Long> {
+        return communityDataSource.likePost(postId, likerId)
+    }
+}

--- a/domain/src/main/java/com/whyranoid/domain/model/post/Post.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/post/Post.kt
@@ -6,6 +6,7 @@ data class Post(
     val id: Long,
     val imageUrl: String,
     val likeCount: Int,
+    val isLiked: Boolean,
     val contents: String,
     val author: User,
     val date: Long = 0L,
@@ -17,6 +18,7 @@ data class Post(
             likeCount = 3,
             contents = "오늘도 상쾌한 달리기~",
             author = User.DUMMY,
+            isLiked = false
         )
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/CommunityRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/CommunityRepository.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.domain.repository
+
+interface CommunityRepository {
+
+    suspend fun likePost(postId: Long, likerId: Long): Result<Long>
+}

--- a/domain/src/main/java/com/whyranoid/domain/usecase/LikePostUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/LikePostUseCase.kt
@@ -1,0 +1,16 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.AccountRepository
+import com.whyranoid.domain.repository.CommunityRepository
+import kotlinx.coroutines.flow.first
+
+class LikePostUseCase(
+    private val communityRepository: CommunityRepository,
+    private val accountRepository: AccountRepository
+) {
+
+    suspend operator fun invoke(postId: Long): Result<Long> {
+        val uid = requireNotNull(accountRepository.uId.first())
+        return communityRepository.likePost(postId, uid)
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/component/community/PostContentItem.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/community/PostContentItem.kt
@@ -17,10 +17,15 @@ import androidx.compose.ui.unit.dp
 import com.whyranoid.domain.model.post.Post
 import com.whyranoid.presentation.icons.buttoniconpack.CommentButtonIcon
 import com.whyranoid.presentation.icons.buttoniconpack.HeartButtonIcon
+import com.whyranoid.presentation.theme.WalkieColor
 import com.whyranoid.presentation.theme.WalkieTypography
 
 @Composable
-fun PostContentItem(post: Post) {
+fun PostContentItem(
+    post: Post,
+    onLikeClicked: (Long) -> Unit = {}
+) {
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -43,11 +48,11 @@ fun PostContentItem(post: Post) {
                     modifier = Modifier
                         .size(20.dp)
                         .clickable {
-
-                        }
-                    ,
+                            onLikeClicked(post.id)
+                        },
                     imageVector = HeartButtonIcon,
                     contentDescription = "좋아요 버튼",
+                    tint = if (post.isLiked) WalkieColor.Primary else WalkieColor.GrayBorder
                 )
 
                 Spacer(modifier = Modifier.size(16.dp))
@@ -57,8 +62,7 @@ fun PostContentItem(post: Post) {
                         .size(20.dp)
                         .clickable {
 
-                        }
-                    ,
+                        },
                     imageVector = CommentButtonIcon,
                     contentDescription = "댓글 버튼",
                 )

--- a/presentation/src/main/java/com/whyranoid/presentation/component/community/PostItem.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/community/PostItem.kt
@@ -14,7 +14,10 @@ import coil.compose.AsyncImage
 import com.whyranoid.domain.model.post.Post
 
 @Composable
-fun PostItem(post: Post) {
+fun PostItem(
+    post: Post,
+    onLikeClicked: (Long) -> Unit = {},
+) {
     Column(
         modifier = Modifier
             .fillMaxHeight()
@@ -36,7 +39,9 @@ fun PostItem(post: Post) {
             contentScale = ContentScale.Crop
         )
 
-        PostContentItem(post)
+        PostContentItem(post) {
+            onLikeClicked(it)
+        }
 
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
@@ -95,7 +95,9 @@ fun CommunityScreen(
 
             state.posts.getDataOrNull()?.forEach { post ->
                 item {
-                    PostItem(post = post)
+                    PostItem(post = post) { postId ->
+                        viewModel.likePost(postId)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 😎 작업 내용
- 게시글 좋아요 기능 구현

## 🧐 변경된 내용
- toPost로 매핑할 때 isLiked 필드가 추가됨.
- Response.getResult 확장함수 추가

<img width="843" alt="Screenshot 2024-01-04 at 1 35 11 PM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/5211f3f4-2d59-4cc7-bedd-9cf18489ad7f">

- map처럼 사용하면 됨


## 🥳 동작 화면

![like](https://github.com/Team-Walkie/Walkie/assets/90144041/cb678098-3801-422e-96f4-eca540b35144)


## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음