### PR TITLE
마이 페이지에서 진행 중인 챌린지 데이터가 없을 때 보이는 화면 구현

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -21,10 +21,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Scaffold
@@ -159,12 +157,11 @@ fun UserPageContent(
         },
     ) { paddingValues ->
 
-        val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
                 .padding(paddingValues)
                 .padding(top = 28.dp)
-                .verticalScroll(scrollState),
+            ,
         ) {
             state.userDetailState.getDataOrNull()?.let { userDetail ->
                 Row(
@@ -354,7 +351,9 @@ fun UserPageContent(
                         }
                     }
 
-                    2 -> ChallengePage()
+                    2 -> ChallengePage {
+
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
@@ -1,7 +1,47 @@
 package com.whyranoid.presentation.screens.mypage.tabs
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.whyranoid.presentation.component.button.WalkiePositiveButton
+import com.whyranoid.presentation.theme.WalkieTypography
 
 @Composable
-fun ChallengePage() {
+fun ChallengePage(
+    onGotoChallengeClicked: () -> Unit
+) {
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        Column {
+            Spacer(modifier = Modifier.height(30.dp))
+            Text(
+                text = "챌린지에 도전하고 프로필에 뱃지를 채워보세요!",
+                style = WalkieTypography.Body1_Normal.copy(color = Color.Black.copy(alpha = 0.5f))
+            )
+        }
+
+        Box(modifier = Modifier.padding(20.dp)) {
+            WalkiePositiveButton(text = "도전하러 가기") {
+                onGotoChallengeClicked()
+            }
+        }
+
+    }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/PostPage.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -54,7 +53,7 @@ fun PostPage(
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        contentAlignment = Alignment.TopCenter,
     ) {
         if (isMyPage.not() && postPreviews.isEmpty()) {
             Column(


### PR DESCRIPTION
## 😎 작업 내용
- 마이 페이지에서 진행 중인 챌린지 데이터가 없을 때 보이는 화면 구현

## 🧐 변경된 내용
- MyPageScreen에서 최상단의 ScrollState 제거

## 🥳 동작 화면
<img width="441" alt="Screenshot 2024-03-07 at 6 16 18 PM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/2649f287-2f50-4e6a-9b1a-0f98a061419d">



## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음