### PR TITLE
Compose/community 댓글 목록 불러오기 화면 구현

### DIFF
--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -23,6 +23,8 @@ object API {
 
     const val LIST_UP_POST = "api/community/listup-post"
 
+    const val LIST_UP_COMMENT = "api/community/listup-comment"
+
     const val SEARCH = "api/community/search-nickname"
 
     const val SEND_LIKE = "api/community/send-like"

--- a/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/post/PostDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.whyranoid.data.datasource.post
 
 import android.util.Log
 import com.whyranoid.domain.datasource.PostDataSource
+import com.whyranoid.domain.model.post.Comment
 import com.whyranoid.domain.model.post.Post
 import com.whyranoid.domain.model.post.PostPreview
 import okhttp3.MediaType
@@ -94,6 +95,22 @@ class PostDataSourceImpl(private val postService: PostService) : PostDataSource 
         return kotlin.runCatching {
             val posts = requireNotNull(postService.getPosts(uid).body())
             posts.map { it.toPost(uid) }
+        }
+    }
+
+    override suspend fun getComments(postId: Long): Result<List<Comment>> {
+        return kotlin.runCatching {
+            val comments = requireNotNull(postService.getComments(postId).body())
+            comments.map {
+                Comment(
+                    it.postId,
+                    it.commenterId,
+                    it.date,
+                    it.content,
+                    it.commentId,
+                    it.commenter,
+                )
+            }
         }
     }
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/post/PostService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/post/PostService.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.data.datasource.post
 
 import com.whyranoid.data.API
+import com.whyranoid.data.model.post.CommentResponse
 import com.whyranoid.data.model.post.PostResponse
 import com.whyranoid.data.model.post.UploadPostResponse
 import okhttp3.MultipartBody
@@ -24,8 +25,17 @@ interface PostService {
     ): Response<UploadPostResponse>
 
     @GET(API.LIST_UP_MY_POST)
-    suspend fun myPosts(@Query("walkieId") uid: Long): Response<List<PostResponse>>
+    suspend fun myPosts(
+        @Query("walkieId") uid: Long,
+    ): Response<List<PostResponse>>
 
     @GET(API.LIST_UP_POST)
-    suspend fun getPosts(@Query("walkieId") uid: Long): Response<List<PostResponse>>
+    suspend fun getPosts(
+        @Query("walkieId") uid: Long,
+    ): Response<List<PostResponse>>
+
+    @GET(API.LIST_UP_COMMENT)
+    suspend fun getComments(
+        @Query("postId") postId: Long,
+    ): Response<List<CommentResponse>>
 }

--- a/data/src/main/java/com/whyranoid/data/model/post/CommentResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/post/CommentResponse.kt
@@ -1,8 +1,8 @@
-package com.whyranoid.domain.model.post
+package com.whyranoid.data.model.post
 
 import com.whyranoid.domain.model.user.User
 
-data class Comment(
+data class CommentResponse(
     val postId: Long,
     val commenterId: Long,
     val date: String,

--- a/data/src/main/java/com/whyranoid/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/PostRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.data.repository
 
 import com.whyranoid.domain.datasource.PostDataSource
+import com.whyranoid.domain.model.post.Comment
 import com.whyranoid.domain.model.post.Post
 import com.whyranoid.domain.model.post.PostPreview
 import com.whyranoid.domain.repository.PostRepository
@@ -50,5 +51,9 @@ class PostRepositoryImpl(
 
     override suspend fun getMyFollowingsPost(uid: Long): Result<List<Post>> {
         return postDataSource.getMyFollowingsPost(uid)
+    }
+
+    override suspend fun getComments(postId: Long): Result<List<Comment>> {
+        return postDataSource.getComments(postId)
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/datasource/PostDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/PostDataSource.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.domain.datasource
 
+import com.whyranoid.domain.model.post.Comment
 import com.whyranoid.domain.model.post.Post
 import com.whyranoid.domain.model.post.PostPreview
 
@@ -33,4 +34,6 @@ interface PostDataSource {
     ): Result<String>
 
     suspend fun getMyFollowingsPost(uid: Long): Result<List<Post>>
+
+    suspend fun getComments(postId: Long): Result<List<Comment>>
 }

--- a/domain/src/main/java/com/whyranoid/domain/model/post/Post.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/post/Post.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.domain.model.post
 
 import com.whyranoid.domain.model.user.User
+import java.io.Serializable
 
 data class Post(
     val id: Long,
@@ -10,15 +11,16 @@ data class Post(
     val contents: String,
     val author: User,
     val date: Long = 0L,
-) {
+) : Serializable {
     companion object {
-        val DUMMY = Post(
-            id = 0L,
-            imageUrl = "https://picsum.photos/250/250",
-            likeCount = 3,
-            contents = "오늘도 상쾌한 달리기~",
-            author = User.DUMMY,
-            isLiked = false
-        )
+        val DUMMY =
+            Post(
+                id = 0L,
+                imageUrl = "https://picsum.photos/250/250",
+                likeCount = 3,
+                contents = "오늘도 상쾌한 달리기~",
+                author = User.DUMMY,
+                isLiked = false,
+            )
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.domain.repository
 
+import com.whyranoid.domain.model.post.Comment
 import com.whyranoid.domain.model.post.Post
 import com.whyranoid.domain.model.post.PostPreview
 
@@ -33,4 +34,6 @@ interface PostRepository {
     ): Result<String>
 
     suspend fun getMyFollowingsPost(uid: Long): Result<List<Post>>
+
+    suspend fun getComments(postId: Long): Result<List<Comment>>
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/component/community/PostContentItem.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/community/PostContentItem.kt
@@ -23,7 +23,8 @@ import com.whyranoid.presentation.theme.WalkieTypography
 @Composable
 fun PostContentItem(
     post: Post,
-    onLikeClicked: (Long) -> Unit = {}
+    onLikeClicked: (Long) -> Unit = {},
+    onCommentClicked: (Post) -> Unit = {},
 ) {
 
     Column(
@@ -61,7 +62,7 @@ fun PostContentItem(
                     modifier = Modifier
                         .size(20.dp)
                         .clickable {
-
+                            onCommentClicked(post)
                         },
                     imageVector = CommentButtonIcon,
                     contentDescription = "댓글 버튼",

--- a/presentation/src/main/java/com/whyranoid/presentation/component/community/PostItem.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/community/PostItem.kt
@@ -19,6 +19,7 @@ fun PostItem(
     post: Post,
     onLikeClicked: (Long) -> Unit = {},
     onProfileClicked: (User) -> Unit = {},
+    onCommentClicked: (Post) -> Unit = {},
 ) {
     Column(
         Modifier.fillMaxHeight(),
@@ -43,8 +44,10 @@ fun PostItem(
             contentScale = ContentScale.Crop,
         )
 
-        PostContentItem(post) {
-            onLikeClicked(it)
-        }
+        PostContentItem(
+            post = post,
+            onLikeClicked =  { onLikeClicked(it) },
+            onCommentClicked = onCommentClicked
+        )
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -25,11 +25,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.whyranoid.domain.model.post.Post
 import com.whyranoid.presentation.screens.Screen.Companion.bottomNavigationItems
 import com.whyranoid.presentation.screens.challenge.ChallengeCompleteScreen
 import com.whyranoid.presentation.screens.challenge.ChallengeDetailScreen
 import com.whyranoid.presentation.screens.challenge.ChallengeExitScreen
 import com.whyranoid.presentation.screens.challenge.ChallengeMainScreen
+import com.whyranoid.presentation.screens.community.CommentScreen
 import com.whyranoid.presentation.screens.community.SearchFriendScreen
 import com.whyranoid.presentation.screens.mypage.MyPageScreen
 import com.whyranoid.presentation.screens.mypage.UserPageScreen
@@ -195,6 +197,16 @@ fun AppScreenContent(
                 val uid = arguments.getLong(Screen.UID_ARGUMENT)
                 val pageNo = arguments.getInt(Screen.PAGE_NO)
                 FollowingScreen(navController = navController, uid = uid, pageNo = pageNo)
+            }
+
+            composable(Screen.CommentScreen.route) {
+                val post = navController.previousBackStackEntry?.savedStateHandle?.get<Post>("post")
+                post?.let {
+                    CommentScreen(
+                        post = it,
+                        onBackClicked = { navController.popBackStack() },
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
@@ -29,9 +29,7 @@ import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
-fun CommunityScreen(
-    navController: NavController,
-) {
+fun CommunityScreen(navController: NavController) {
     val viewModel = koinViewModel<CommunityScreenViewModel>()
     val state by viewModel.collectAsState()
 
@@ -48,9 +46,10 @@ fun CommunityScreen(
                         Spacer(modifier = Modifier.width(7.dp))
 
                         Icon(
-                            modifier = Modifier
-                                .clickable {
-                                },
+                            modifier =
+                                Modifier
+                                    .clickable {
+                                    },
                             imageVector = Icons.Filled.KeyboardArrowDown,
                             contentDescription = "Down Arrow",
                         )
@@ -59,9 +58,10 @@ fun CommunityScreen(
                 rightContent = {
                     Row {
                         Icon(
-                            modifier = Modifier
-                                .clickable {
-                                },
+                            modifier =
+                                Modifier
+                                    .clickable {
+                                    },
                             imageVector = Icons.Filled.Add,
                             contentDescription = "추가 버튼",
                         )
@@ -69,10 +69,11 @@ fun CommunityScreen(
                         Spacer(modifier = Modifier.width(16.dp))
 
                         Icon(
-                            modifier = Modifier
-                                .clickable {
-                                    navController.navigate(Screen.SearchFriendScreen.route)
-                                },
+                            modifier =
+                                Modifier
+                                    .clickable {
+                                        navController.navigate(Screen.SearchFriendScreen.route)
+                                    },
                             imageVector = Icons.Filled.Search,
                             contentDescription = "검색 버튼",
                         )
@@ -106,8 +107,9 @@ fun CommunityScreen(
                             }
                         },
                         onCommentClicked = { post ->
-
-                        }
+                            navController.currentBackStackEntry?.savedStateHandle?.set("post", post)
+                            navController.navigate(Screen.CommentScreen.route)
+                        },
                     )
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/CommunityScreen.kt
@@ -105,6 +105,9 @@ fun CommunityScreen(
                                 navController.navigate("userPage/${user.uid}/${user.nickname}/$isFollowing")
                             }
                         },
+                        onCommentClicked = { post ->
+
+                        }
                     )
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/Screen.kt
@@ -14,7 +14,6 @@ sealed class Screen(
     @DrawableRes val iconSelected: Int? = null,
     val arguments: List<NamedNavArgument> = emptyList(),
 ) {
-
     object Running : Screen(
         "running",
         R.string.running,
@@ -54,11 +53,12 @@ sealed class Screen(
 
     object EditProfileScreen : Screen(
         route = "editProfileScreen",
-        arguments = listOf(
-            navArgument("imageUrl") { type = NavType.StringType },
-            navArgument("name") { type = NavType.StringType },
-            navArgument("nickName") { type = NavType.StringType },
-        ),
+        arguments =
+            listOf(
+                navArgument("imageUrl") { type = NavType.StringType },
+                navArgument("name") { type = NavType.StringType },
+                navArgument("nickName") { type = NavType.StringType },
+            ),
     ) {
         const val IMAGE_URL_KEY = "imageUrl"
         const val NAME_KEY = "name"
@@ -67,46 +67,62 @@ sealed class Screen(
 
     object ChallengeDetailScreen : Screen(
         route = "challengeDetail/{challengeId}/{isChallenging}",
-        arguments = listOf(
-            navArgument("challengeId") { type = NavType.LongType },
-            navArgument("isChallenging") { type = NavType.BoolType },
-        ),
+        arguments =
+            listOf(
+                navArgument("challengeId") { type = NavType.LongType },
+                navArgument("isChallenging") { type = NavType.BoolType },
+            ),
     )
 
     object ChallengeExitScreen : Screen(
         route = "challengeExit/{challengeId}",
-        arguments = listOf(
-            navArgument("challengeId") { type = NavType.LongType },
-        ),
+        arguments =
+            listOf(
+                navArgument("challengeId") { type = NavType.LongType },
+            ),
     )
 
     object ChallengeCompleteScreen : Screen(
         route = "challengeComplete/{challengeId}",
-        arguments = listOf(
-            navArgument("challengeId") { type = NavType.LongType },
-        ),
+        arguments =
+            listOf(
+                navArgument("challengeId") { type = NavType.LongType },
+            ),
     )
 
     object UserPageScreen : Screen(
         route = "userPage/{$UID_ARGUMENT}/{$NICKNAME_ARGUMENT}/{$IS_FOLLOWING_ARGUMENT}",
-        arguments = listOf(
-            navArgument(UID_ARGUMENT) { type = NavType.LongType },
-            navArgument(NICKNAME_ARGUMENT) { type = NavType.StringType },
-            navArgument(IS_FOLLOWING_ARGUMENT) { type = NavType.BoolType },
-        ),
+        arguments =
+            listOf(
+                navArgument(UID_ARGUMENT) { type = NavType.LongType },
+                navArgument(NICKNAME_ARGUMENT) { type = NavType.StringType },
+                navArgument(IS_FOLLOWING_ARGUMENT) { type = NavType.BoolType },
+            ),
     )
 
     object FollowingScreen : Screen(
         route = "followingScreen/{$UID_ARGUMENT}/{$PAGE_NO}",
-        arguments = listOf(
-            navArgument(UID_ARGUMENT) { type = NavType.LongType },
-            navArgument(PAGE_NO) { type = NavType.IntType },
-        ),
+        arguments =
+            listOf(
+                navArgument(UID_ARGUMENT) { type = NavType.LongType },
+                navArgument(PAGE_NO) { type = NavType.IntType },
+            ),
     ) {
-        fun route(uid: Long, pageNo: Int): String {
+        fun route(
+            uid: Long,
+            pageNo: Int,
+        ): String {
             return "followingScreen/$uid/$pageNo"
         }
     }
+
+    object CommentScreen : Screen(
+        route = "commentScreen/{$POST_ID}",
+        arguments =
+            listOf(
+                navArgument(POST_ID) { type = NavType.LongType },
+            ),
+    )
 
     companion object {
         val bottomNavigationItems = listOf(Running, Community, ChallengeMainScreen, MyPage)
@@ -115,5 +131,6 @@ sealed class Screen(
         const val NICKNAME_ARGUMENT = "nickname"
         const val IS_FOLLOWING_ARGUMENT = "isFollowing"
         const val PAGE_NO = "pageNo"
+        const val POST_ID = "postId"
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/community/CommentScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/community/CommentScreen.kt
@@ -1,0 +1,181 @@
+package com.whyranoid.presentation.screens.community
+
+import android.annotation.SuppressLint
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.whyranoid.domain.model.post.Comment
+import com.whyranoid.domain.model.post.Post
+import com.whyranoid.domain.repository.PostRepository
+import com.whyranoid.presentation.component.bar.WalkieTopBar
+import com.whyranoid.presentation.theme.WalkieColor
+import com.whyranoid.presentation.theme.WalkieTheme
+import com.whyranoid.presentation.theme.WalkieTypography
+import org.koin.androidx.compose.get
+
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
+@Composable
+fun CommentScreen(
+    modifier: Modifier = Modifier,
+    post: Post,
+    onProfileClicked: (uid: Long) -> Unit = { },
+    onBackClicked: () -> Unit = { },
+    postRepo: PostRepository = get(),
+) {
+    var comments by remember { mutableStateOf<List<Comment>?>(null) }
+    LaunchedEffect(post.id) {
+        postRepo.getComments(post.id).onSuccess {
+            comments = it
+            Log.d("ju0828", it.toString())
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            WalkieTopBar(
+                middleContent = {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            modifier =
+                                Modifier.align(Alignment.CenterStart)
+                                    .clickable { onBackClicked() },
+                            imageVector = Icons.Filled.KeyboardArrowLeft,
+                            contentDescription = "Left Arrow",
+                        )
+
+                        Text(
+                            text = "댓글",
+                            style = WalkieTypography.Title.copy(fontWeight = FontWeight(600)),
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column {
+            Column(
+                modifier = Modifier.padding(paddingValues).padding(horizontal = 20.dp),
+            ) {
+                PostComment(
+                    post.author.uid,
+                    post.author.imageUrl,
+                    post.author.nickname,
+                    post.contents,
+                    onProfileClicked,
+                )
+            }
+
+            Box(
+                modifier =
+                    Modifier.padding(top = 16.dp).height(1.dp).fillMaxWidth()
+                        .background(WalkieColor.GrayBorder),
+            )
+
+            LazyColumn(
+                modifier =
+                    Modifier.fillMaxSize().padding(top = 16.dp)
+                        .padding(paddingValues).padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(all = 16.dp),
+            ) {
+                comments?.let { list ->
+                    items(list.size) { index ->
+                        PostComment(
+                            list[index].commenterId,
+                            list[index].commenter.imageUrl,
+                            list[index].commenter.nickname,
+                            list[index].content,
+                            onProfileClicked,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PostComment(
+    uid: Long,
+    imageUrl: String,
+    nickname: String,
+    content: String,
+    onProfileClicked: (uid: Long) -> Unit = { },
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = "user image",
+            modifier =
+                Modifier
+                    .size(34.dp)
+                    .clip(RoundedCornerShape(50.dp))
+                    .clickable { onProfileClicked(uid) },
+            contentScale = ContentScale.Crop,
+        )
+
+        val text =
+            buildAnnotatedString {
+                withStyle(
+                    SpanStyle(fontWeight = FontWeight.Bold),
+                ) {
+                    append(nickname)
+                }
+                append(" $content")
+            }
+
+        Text(
+            modifier = Modifier.padding(start = 8.dp),
+            text = text,
+            style = WalkieTypography.Body2,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun CommentScreenPreview() {
+    WalkieTheme {
+        CommentScreen(post = Post.DUMMY)
+    }
+}


### PR DESCRIPTION
## 😎 작업 내용
- 댓글 목록 불러오기 화면 구현

## 🧐 변경된 내용
- 작성된 댓글을 불러오는 로직 구현
- 아직 댓글 작성 로직을 미구현으로 불러와지는 댓글은 안보임

## 🥳 동작 화면
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/c66956df-03df-4325-ac20-3267c39befbb" width = "320">

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음