### PR TITLE
챌린지 API 연결 - 메인 페이지, 상세 페이지 및 도전하기 기능

### DIFF
--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -66,6 +66,7 @@ import com.whyranoid.domain.usecase.GetUserPostPreviewsUseCase
 import com.whyranoid.domain.usecase.LikePostUseCase
 import com.whyranoid.domain.usecase.RequestLoginUseCase
 import com.whyranoid.domain.usecase.SignOutUseCase
+import com.whyranoid.domain.usecase.StartChallengeUseCase
 import com.whyranoid.domain.usecase.UploadPostUseCase
 import com.whyranoid.domain.usecase.broadcast.AddGpsListener
 import com.whyranoid.domain.usecase.broadcast.AddNetworkListener
@@ -108,7 +109,7 @@ import java.util.concurrent.TimeUnit
 
 val viewModelModule = module {
     single { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
-    single { ChallengeDetailViewModel(get()) }
+    single { ChallengeDetailViewModel(get(), get()) }
     single { ChallengeExitViewModel(get()) }
     factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
@@ -181,6 +182,7 @@ val useCaseModule = module {
     single { GetMyUidUseCase(get()) }
     single { RemoveFollowerUseCase(get(), get()) }
     single { GetMyFollowingUseCase(get(), get()) }
+    single { StartChallengeUseCase(get(), get()) }
 }
 
 val databaseModule = module {

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -59,6 +59,7 @@ import com.whyranoid.domain.usecase.GetMyFollowingUseCase
 import com.whyranoid.domain.usecase.GetMyUidUseCase
 import com.whyranoid.domain.usecase.GetNewChallengePreviewsUseCase
 import com.whyranoid.domain.usecase.GetPostUseCase
+import com.whyranoid.domain.usecase.GetTopRankChallengePreviewsUseCase
 import com.whyranoid.domain.usecase.GetUserBadgesUseCase
 import com.whyranoid.domain.usecase.GetUserDetailUseCase
 import com.whyranoid.domain.usecase.GetUserPostPreviewsUseCase
@@ -106,7 +107,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 val viewModelModule = module {
-    single { ChallengeMainViewModel(get(), get(), get(), get()) }
+    single { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
     single { ChallengeDetailViewModel(get()) }
     single { ChallengeExitViewModel(get()) }
     factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
@@ -152,6 +153,7 @@ val useCaseModule = module {
     single { GetChallengingPreviewsUseCase(get()) }
     single { GetChallengeDetailUseCase(get()) }
     single { GetChallengePreviewsByTypeUseCase(get()) }
+    single { GetTopRankChallengePreviewsUseCase(get()) }
     single { GetPostUseCase(get()) }
     single { GetUserPostPreviewsUseCase(get(), get()) }
     single { GetUserBadgesUseCase(get()) }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -151,7 +151,7 @@ val dataSourceModule = module {
 val useCaseModule = module {
     single { GetNewChallengePreviewsUseCase(get()) }
     single { GetChallengingPreviewsUseCase(get()) }
-    single { GetChallengeDetailUseCase(get()) }
+    single { GetChallengeDetailUseCase(get(), get()) }
     single { GetChallengePreviewsByTypeUseCase(get(), get()) }
     single { GetTopRankChallengePreviewsUseCase(get()) }
     single { GetPostUseCase(get()) }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -6,11 +6,12 @@ import com.google.gson.GsonBuilder
 import com.whyranoid.data.API
 import com.whyranoid.data.AccountDataStore
 import com.whyranoid.data.AppDatabase
-import com.whyranoid.data.datasource.ChallengeDataSourceImpl
+import com.whyranoid.data.datasource.challenge.ChallengeDataSourceImpl
 import com.whyranoid.data.datasource.OtherUserPagingSource
 import com.whyranoid.data.datasource.UserDataSourceImpl
 import com.whyranoid.data.datasource.account.AccountDataSourceImpl
 import com.whyranoid.data.datasource.account.AccountService
+import com.whyranoid.data.datasource.challenge.ChallengeService
 import com.whyranoid.data.datasource.community.CommunityDataSource
 import com.whyranoid.data.datasource.community.CommunityDataSourceImpl
 import com.whyranoid.data.datasource.community.CommunityService
@@ -105,7 +106,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 val viewModelModule = module {
-    single { ChallengeMainViewModel(get(), get(), get()) }
+    single { ChallengeMainViewModel(get(), get(), get(), get()) }
     single { ChallengeDetailViewModel(get()) }
     single { ChallengeExitViewModel(get()) }
     factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
@@ -137,7 +138,7 @@ val repositoryModule = module {
 }
 
 val dataSourceModule = module {
-    single<ChallengeDataSource> { ChallengeDataSourceImpl() }
+    single<ChallengeDataSource> { ChallengeDataSourceImpl(get()) }
     single<PostDataSource> { PostDataSourceImpl(get()) }
     single<UserDataSource> { UserDataSourceImpl(get()) }
     single<AccountDataSource> { AccountDataSourceImpl(get()) }
@@ -245,4 +246,6 @@ val networkModule = module {
     single { get<Retrofit>().create(RunningService::class.java) }
 
     single { get<Retrofit>().create(CommunityService::class.java) }
+
+    single { get<Retrofit>().create(ChallengeService::class.java) }
 }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -152,7 +152,7 @@ val useCaseModule = module {
     single { GetNewChallengePreviewsUseCase(get()) }
     single { GetChallengingPreviewsUseCase(get()) }
     single { GetChallengeDetailUseCase(get()) }
-    single { GetChallengePreviewsByTypeUseCase(get()) }
+    single { GetChallengePreviewsByTypeUseCase(get(), get()) }
     single { GetTopRankChallengePreviewsUseCase(get()) }
     single { GetPostUseCase(get()) }
     single { GetUserPostPreviewsUseCase(get(), get()) }

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -33,6 +33,8 @@ object API {
 
     const val PROGRESSING_CHALLENGE = "api/challenge/challenges/progress"
 
+    const val TOP_RANK_CHALLENGE = "api/challenge/challenges/top-rank"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -31,6 +31,8 @@ object API {
 
     const val NEW_CHALLENGE = "/api/challenge/challenges/new"
 
+    const val PROGRESSING_CHALLENGE = "api/challenge/challenges/progress"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -29,6 +29,8 @@ object API {
 
     const val LOGIN = "api/walkies/login"
 
+    const val NEW_CHALLENGE = "/api/challenge/challenges/new"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -39,6 +39,8 @@ object API {
 
     const val CHALLENGE_DETAIL = "api/challenge/challenge-detail"
 
+    const val CHALLENGE_START = "api/challenge/challenge-detail/start"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -37,6 +37,8 @@ object API {
 
     const val CHALLENGE_CATEGORY = "api/challenge/challenges/category"
 
+    const val CHALLENGE_DETAIL = "api/challenge/challenge-detail"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -35,6 +35,8 @@ object API {
 
     const val TOP_RANK_CHALLENGE = "api/challenge/challenges/top-rank"
 
+    const val CHALLENGE_CATEGORY = "api/challenge/challenges/category"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -10,7 +10,6 @@ import com.whyranoid.domain.model.challenge.ChallengeType
 class ChallengeDataSourceImpl(
     private val challengeService: ChallengeService,
 ) : ChallengeDataSource {
-    // TODO: change to api call
     override suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>> {
         return kotlin.runCatching {
             val response = challengeService.getNewChallenges(uid)
@@ -20,9 +19,13 @@ class ChallengeDataSourceImpl(
         }
     }
 
-    // TODO: change to api call
-    override suspend fun getChallengingPreviews(): List<ChallengePreview> {
-        return List(10) { ChallengePreview.DUMMY }
+    override suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>> {
+        return kotlin.runCatching {
+            val response = challengeService.getMyProcessingChallenges(uid)
+            response.getResult { list ->
+                list.map { it.toChallengePreview()}
+            }
+        }
     }
 
     // TODO: change to api call

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.data.datasource.challenge
 
 import com.whyranoid.data.getResult
+import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
 import com.whyranoid.domain.datasource.ChallengeDataSource
 import com.whyranoid.domain.model.challenge.Badge
 import com.whyranoid.domain.model.challenge.Challenge
@@ -54,5 +55,11 @@ class ChallengeDataSourceImpl(
     // TODO: change to api call
     override suspend fun getUserBadges(uid: Long): Result<List<Badge>> {
         return Result.success(Badge.DUMMY_LIST)
+    }
+
+    override suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit> {
+        return runCatching {
+            challengeService.startChallenge(ChallengeStartRequest(uid, challengeId))
+        }
     }
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -28,6 +28,15 @@ class ChallengeDataSourceImpl(
         }
     }
 
+    override suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>> {
+        return kotlin.runCatching {
+            val response = challengeService.getTopRankChallenges()
+            response.getResult { list ->
+                list.map { it.toChallengePreview()}
+            }
+        }
+    }
+
     // TODO: change to api call
     override suspend fun getChallengeDetail(challengeId: Long): Challenge {
         return Challenge.DUMMY.copy(

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -44,9 +44,10 @@ class ChallengeDataSourceImpl(
         )
     }
 
-    // TODO: change to api call
-    override suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview> {
-        return List(3) { ChallengePreview.DUMMY }
+    override suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview> {
+        return challengeService.getChallengePreviewsByType(uid, type.serverString).getResult { list ->
+            list.map { it.toChallengePreview() }
+        }
     }
 
     // TODO: change to api call

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -23,7 +23,7 @@ class ChallengeDataSourceImpl(
         return kotlin.runCatching {
             val response = challengeService.getMyProcessingChallenges(uid)
             response.getResult { list ->
-                list.map { it.toChallengePreview()}
+                list.map { it.toChallengePreview() }
             }
         }
     }
@@ -32,22 +32,23 @@ class ChallengeDataSourceImpl(
         return kotlin.runCatching {
             val response = challengeService.getTopRankChallenges()
             response.getResult { list ->
-                list.map { it.toChallengePreview()}
+                list.map { it.toChallengePreview() }
             }
         }
     }
 
-    // TODO: change to api call
-    override suspend fun getChallengeDetail(challengeId: Long): Challenge {
-        return Challenge.DUMMY.copy(
-            id = challengeId,
-        )
+    override suspend fun getChallengeDetail(uid: Int, challengeId: Long): Challenge {
+        return challengeService.getChallengeDetail(challengeId, uid).getResult { it.toChallenge() }
     }
 
-    override suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview> {
-        return challengeService.getChallengePreviewsByType(uid, type.serverString).getResult { list ->
-            list.map { it.toChallengePreview() }
-        }
+    override suspend fun getChallengePreviewsByType(
+        uid: Int,
+        type: ChallengeType
+    ): List<ChallengePreview> {
+        return challengeService.getChallengePreviewsByType(uid, type.serverString)
+            .getResult { list ->
+                list.map { it.toChallengePreview() }
+            }
     }
 
     // TODO: change to api call

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -1,15 +1,23 @@
-package com.whyranoid.data.datasource
+package com.whyranoid.data.datasource.challenge
 
+import com.whyranoid.data.getResult
 import com.whyranoid.domain.datasource.ChallengeDataSource
 import com.whyranoid.domain.model.challenge.Badge
 import com.whyranoid.domain.model.challenge.Challenge
 import com.whyranoid.domain.model.challenge.ChallengePreview
 import com.whyranoid.domain.model.challenge.ChallengeType
 
-class ChallengeDataSourceImpl : ChallengeDataSource {
+class ChallengeDataSourceImpl(
+    private val challengeService: ChallengeService,
+) : ChallengeDataSource {
     // TODO: change to api call
-    override suspend fun getNewChallengePreviews(): List<ChallengePreview> {
-        return List(10) { ChallengePreview.DUMMY }
+    override suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>> {
+        return kotlin.runCatching {
+            val response = challengeService.getNewChallenges(uid)
+            response.getResult { list ->
+                list.map { it.toChallengePreview() }
+            }
+        }
     }
 
     // TODO: change to api call

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -12,4 +12,8 @@ interface ChallengeService {
     suspend fun getNewChallenges(
         @Query("walkieId") uid: Int,
     ): Response<List<ChallengePreviewResponse>>
+
+    @GET(API.PROGRESSING_CHALLENGE)
+    suspend fun getMyProcessingChallenges(@Query("walkieId") uid: Int): Response<List<ChallengePreviewResponse>>
+
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -1,10 +1,14 @@
 package com.whyranoid.data.datasource.challenge
 
 import com.whyranoid.data.API
+import com.whyranoid.data.model.StatusWithMessage
 import com.whyranoid.data.model.challenge.ChallengeDetailResponse
 import com.whyranoid.data.model.challenge.ChallengePreviewResponse
+import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface ChallengeService {
@@ -31,4 +35,9 @@ interface ChallengeService {
         @Query("challengeId") challengeId: Long,
         @Query("walkieId") uid: Int,
     ): Response<ChallengeDetailResponse>
+
+    @POST(API.CHALLENGE_START)
+    suspend fun startChallenge(
+        @Body challengeStartRequest: ChallengeStartRequest
+    ): Response<StatusWithMessage>
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.data.datasource.challenge
 
 import com.whyranoid.data.API
+import com.whyranoid.data.model.challenge.ChallengeDetailResponse
 import com.whyranoid.data.model.challenge.ChallengePreviewResponse
 import retrofit2.Response
 import retrofit2.http.GET
@@ -25,4 +26,9 @@ interface ChallengeService {
         @Query("category") type: String
     ): Response<List<ChallengePreviewResponse>>
 
+    @GET(API.CHALLENGE_DETAIL)
+    suspend fun getChallengeDetail(
+        @Query("challengeId") challengeId: Long,
+        @Query("walkieId") uid: Int,
+    ): Response<ChallengeDetailResponse>
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -16,4 +16,7 @@ interface ChallengeService {
     @GET(API.PROGRESSING_CHALLENGE)
     suspend fun getMyProcessingChallenges(@Query("walkieId") uid: Int): Response<List<ChallengePreviewResponse>>
 
+    @GET(API.TOP_RANK_CHALLENGE)
+    suspend fun getTopRankChallenges(): Response<List<ChallengePreviewResponse>>
+
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -19,4 +19,10 @@ interface ChallengeService {
     @GET(API.TOP_RANK_CHALLENGE)
     suspend fun getTopRankChallenges(): Response<List<ChallengePreviewResponse>>
 
+    @GET(API.CHALLENGE_CATEGORY)
+    suspend fun getChallengePreviewsByType(
+        @Query("walkieId") uid: Int,
+        @Query("category") type: String
+    ): Response<List<ChallengePreviewResponse>>
+
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.data.datasource.challenge
+
+import com.whyranoid.data.API
+import com.whyranoid.data.model.challenge.ChallengePreviewResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ChallengeService {
+
+    @GET(API.NEW_CHALLENGE)
+    suspend fun getNewChallenges(
+        @Query("walkieId") uid: Int,
+    ): Response<List<ChallengePreviewResponse>>
+}

--- a/data/src/main/java/com/whyranoid/data/model/StatusWithMessage.kt
+++ b/data/src/main/java/com/whyranoid/data/model/StatusWithMessage.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.data.model
+
+data class StatusWithMessage(
+    val message: String,
+    val status: Int
+)

--- a/data/src/main/java/com/whyranoid/data/model/challenge/BadgeResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/BadgeResponse.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.data.model.challenge
+
+data class BadgeResponse(
+    val badgeId: Int,
+    val badgeName: String,
+    val img: String
+) {
+    fun toBadge(): com.whyranoid.domain.model.challenge.Badge {
+        return com.whyranoid.domain.model.challenge.Badge(
+            id = badgeId.toLong(),
+            name = badgeName,
+            imageUrl = img
+        )
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/model/challenge/ChallengeDetailResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/ChallengeDetailResponse.kt
@@ -1,0 +1,23 @@
+package com.whyranoid.data.model.challenge
+
+import com.whyranoid.domain.model.challenge.ChallengeType
+
+data class ChallengeDetailResponse(
+    val challenge: ChallengeFromServer,
+    val walkies: List<Walkie>
+) {
+    fun toChallenge(): com.whyranoid.domain.model.challenge.Challenge {
+        val participants = walkies.map { it.toUser() }
+        return com.whyranoid.domain.model.challenge.Challenge(
+            badge = challenge.badge.toBadge(),
+            challengeType = ChallengeType.getChallengeTypeByString(challenge.category),
+            id = challenge.challengeId.toLong(),
+            contents = challenge.content,
+            imageUrl = challenge.img,
+            title = challenge.name,
+            process = challenge.progress,
+            participants = participants,
+            participantCount = participants.size,
+        )
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/model/challenge/ChallengeFromServer.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/ChallengeFromServer.kt
@@ -1,0 +1,12 @@
+package com.whyranoid.data.model.challenge
+
+data class ChallengeFromServer(
+    val badge: BadgeResponse,
+    val category: String,
+    val challengeId: Int,
+    val content: String,
+    val img: String,
+    val name: String,
+    val progress: Int?,
+    val status: String?
+)

--- a/data/src/main/java/com/whyranoid/data/model/challenge/ChallengePreviewResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/ChallengePreviewResponse.kt
@@ -1,0 +1,22 @@
+package com.whyranoid.data.model.challenge
+
+import com.whyranoid.domain.model.challenge.ChallengePreview
+import com.whyranoid.domain.model.challenge.ChallengeType
+
+data class ChallengePreviewResponse(
+    val category: String,
+    val challengeId: Int,
+    val name: String,
+    val newFlag: Int,
+    val progress: Int,
+    val status: String
+) {
+    fun toChallengePreview(): ChallengePreview {
+        return ChallengePreview(
+            id = challengeId.toLong(),
+            title = name,
+            progress = progress.toFloat(),
+            type = ChallengeType.getChallengeTypeByString(category)
+        )
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/model/challenge/Walkie.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/Walkie.kt
@@ -1,0 +1,20 @@
+package com.whyranoid.data.model.challenge
+
+import com.whyranoid.domain.model.user.User
+
+data class Walkie(
+    val authId: String,
+    val profileImg: String,
+    val status: String,
+    val userId: Int,
+    val userName: String
+) {
+    fun toUser(): User {
+        return User(
+            uid = userId.toLong(),
+            name = userName,
+            nickname = userName,
+            imageUrl = profileImg
+        )
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/model/challenge/request/ChallengeStartRequest.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/request/ChallengeStartRequest.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.data.model.challenge.request
+
+data class ChallengeStartRequest(
+    val walkieId: Int,
+    val challengeId: Int,
+)

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -26,8 +26,8 @@ class ChallengeRepositoryImpl(
         return challengeDataSource.getChallengeDetail(challengeId)
     }
 
-    override suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview> {
-        return challengeDataSource.getChallengePreviewsByType(type)
+    override suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview> {
+        return challengeDataSource.getChallengePreviewsByType(uid, type)
     }
 
     override suspend fun getUserBadges(uid: Long): Result<List<Badge>> {

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -18,6 +18,10 @@ class ChallengeRepositoryImpl(
         return challengeDataSource.getChallengingPreviews(uid)
     }
 
+    override suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>> {
+        return challengeDataSource.getTopRankChallengePreviews()
+    }
+
     override suspend fun getChallengeDetail(challengeId: Long): Challenge {
         return challengeDataSource.getChallengeDetail(challengeId)
     }

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -10,8 +10,8 @@ import com.whyranoid.domain.repository.ChallengeRepository
 class ChallengeRepositoryImpl(
     private val challengeDataSource: ChallengeDataSource,
 ) : ChallengeRepository {
-    override suspend fun getNewChallengePreviews(): List<ChallengePreview> {
-        return challengeDataSource.getNewChallengePreviews()
+    override suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>> {
+        return challengeDataSource.getNewChallengePreviews(uid)
     }
 
     override suspend fun getChallengingPreviews(): List<ChallengePreview> {

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -22,8 +22,8 @@ class ChallengeRepositoryImpl(
         return challengeDataSource.getTopRankChallengePreviews()
     }
 
-    override suspend fun getChallengeDetail(challengeId: Long): Challenge {
-        return challengeDataSource.getChallengeDetail(challengeId)
+    override suspend fun getChallengeDetail(uid: Int, challengeId: Long): Challenge {
+        return challengeDataSource.getChallengeDetail(uid, challengeId)
     }
 
     override suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview> {

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -14,8 +14,8 @@ class ChallengeRepositoryImpl(
         return challengeDataSource.getNewChallengePreviews(uid)
     }
 
-    override suspend fun getChallengingPreviews(): List<ChallengePreview> {
-        return challengeDataSource.getChallengingPreviews()
+    override suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>> {
+        return challengeDataSource.getChallengingPreviews(uid)
     }
 
     override suspend fun getChallengeDetail(challengeId: Long): Challenge {

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -33,4 +33,8 @@ class ChallengeRepositoryImpl(
     override suspend fun getUserBadges(uid: Long): Result<List<Badge>> {
         return challengeDataSource.getUserBadges(uid)
     }
+
+    override suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit> {
+        return challengeDataSource.startChallenge(uid, challengeId)
+    }
 }

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -15,7 +15,7 @@ interface ChallengeDataSource {
 
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 
-    suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview>
+    suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
 }

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -7,7 +7,7 @@ import com.whyranoid.domain.model.challenge.ChallengeType
 
 interface ChallengeDataSource {
 
-    suspend fun getNewChallengePreviews(): List<ChallengePreview>
+    suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>>
 
     suspend fun getChallengingPreviews(): List<ChallengePreview>
 

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -9,7 +9,7 @@ interface ChallengeDataSource {
 
     suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>>
 
-    suspend fun getChallengingPreviews(): List<ChallengePreview>
+    suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>>
 
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -11,6 +11,8 @@ interface ChallengeDataSource {
 
     suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>>
 
+    suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>>
+
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 
     suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview>

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -13,7 +13,7 @@ interface ChallengeDataSource {
 
     suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>>
 
-    suspend fun getChallengeDetail(challengeId: Long): Challenge
+    suspend fun getChallengeDetail(uid: Int, challengeId: Long): Challenge
 
     suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -18,4 +18,6 @@ interface ChallengeDataSource {
     suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
+
+    suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/whyranoid/domain/model/challenge/Challenge.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/challenge/Challenge.kt
@@ -7,12 +7,12 @@ data class Challenge(
     val imageUrl: String,
     val title: String,
     val contents: String,
-    val period: Int,
+    val period: Int? = null,
     val challengeType: ChallengeType,
     val badge: Badge,
     val participantCount: Int,
     val participants: List<User>,
-    val process: Int?,
+    val process: Int? = null,
 ) {
     companion object {
 

--- a/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengePreview.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengePreview.kt
@@ -3,7 +3,6 @@ package com.whyranoid.domain.model.challenge
 data class ChallengePreview(
     val id: Long,
     val title: String,
-    val badgeImageUrl: String,
     val progress: Float?,
     val type: ChallengeType
 ) {
@@ -40,7 +39,6 @@ data class ChallengePreview(
             get() = ChallengePreview(
                 id = DUMMY_ID_LIST.shuffled().first(),
                 title = DUMMY_NAME_LIST.shuffled().first(),
-                badgeImageUrl = "https://picsum.photos/250/250",
                 progress = DUMMY_PROGRESS_LIST.shuffled().first(),
                 type = ChallengeType.values().toList().shuffled().first(),
             )

--- a/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengeType.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengeType.kt
@@ -1,8 +1,8 @@
 package com.whyranoid.domain.model.challenge
 
 // TODO: 기획이 구체화되면 수정
-enum class ChallengeType(val text: String) {
-    LIFE("라이프"), CALORIE("칼로리"), DISTANCE("거리");
+enum class ChallengeType(val text: String, val serverString: String) {
+    LIFE("라이프", "L"), CALORIE("칼로리", "C"), DISTANCE("거리", "D");
 
     companion object {
         fun getChallengeTypeByString(type: String): ChallengeType {

--- a/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengeType.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/challenge/ChallengeType.kt
@@ -2,5 +2,15 @@ package com.whyranoid.domain.model.challenge
 
 // TODO: 기획이 구체화되면 수정
 enum class ChallengeType(val text: String) {
-    LIFE("라이프"), CALORIE("칼로리"), DISTANCE("거리")
+    LIFE("라이프"), CALORIE("칼로리"), DISTANCE("거리");
+
+    companion object {
+        fun getChallengeTypeByString(type: String): ChallengeType {
+            return when (type) {
+                "L" -> LIFE
+                "C" -> CALORIE
+                else -> DISTANCE
+            }
+        }
+    }
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -9,7 +9,7 @@ interface ChallengeRepository {
 
     suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>>
 
-    suspend fun getChallengingPreviews(): List<ChallengePreview>
+    suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>>
 
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -18,4 +18,6 @@ interface ChallengeRepository {
     suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
+
+    suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -15,7 +15,7 @@ interface ChallengeRepository {
 
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 
-    suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview>
+    suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -13,7 +13,7 @@ interface ChallengeRepository {
 
     suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>>
 
-    suspend fun getChallengeDetail(challengeId: Long): Challenge
+    suspend fun getChallengeDetail(uid: Int, challengeId: Long): Challenge
 
     suspend fun getChallengePreviewsByType(uid: Int, type: ChallengeType): List<ChallengePreview>
 

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -7,7 +7,7 @@ import com.whyranoid.domain.model.challenge.ChallengeType
 
 interface ChallengeRepository {
 
-    suspend fun getNewChallengePreviews(): List<ChallengePreview>
+    suspend fun getNewChallengePreviews(uid: Int): Result<List<ChallengePreview>>
 
     suspend fun getChallengingPreviews(): List<ChallengePreview>
 

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -11,6 +11,8 @@ interface ChallengeRepository {
 
     suspend fun getChallengingPreviews(uid: Int): Result<List<ChallengePreview>>
 
+    suspend fun getTopRankChallengePreviews(): Result<List<ChallengePreview>>
+
     suspend fun getChallengeDetail(challengeId: Long): Challenge
 
     suspend fun getChallengePreviewsByType(type: ChallengeType): List<ChallengePreview>

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengeDetailUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengeDetailUseCase.kt
@@ -1,10 +1,13 @@
 package com.whyranoid.domain.usecase
 
+import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.repository.ChallengeRepository
 
 class GetChallengeDetailUseCase(
-    private val challengeRepository: ChallengeRepository
+    private val accountRepository: AccountRepository,
+    private val challengeRepository: ChallengeRepository,
 ) {
 
-    suspend operator fun invoke(challengeId: Long) = challengeRepository.getChallengeDetail(challengeId)
+    suspend operator fun invoke(challengeId: Long) = challengeRepository.getChallengeDetail(
+        accountRepository.getUID().toInt(), challengeId)
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengePreviewsByTypeUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengePreviewsByTypeUseCase.kt
@@ -2,12 +2,17 @@ package com.whyranoid.domain.usecase
 
 import com.whyranoid.domain.model.challenge.ChallengePreview
 import com.whyranoid.domain.model.challenge.ChallengeType
+import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.repository.ChallengeRepository
+import kotlinx.coroutines.flow.first
 
 class GetChallengePreviewsByTypeUseCase(
-    private val challengeRepository: ChallengeRepository
+    private val challengeRepository: ChallengeRepository,
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(type: ChallengeType): List<ChallengePreview> {
-        return challengeRepository.getChallengePreviewsByType(type)
+        return challengeRepository.getChallengePreviewsByType(
+            accountRepository.uId.first()?.toInt() ?: -1, type
+        )
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengingPreviewsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetChallengingPreviewsUseCase.kt
@@ -6,7 +6,7 @@ import com.whyranoid.domain.repository.ChallengeRepository
 class GetChallengingPreviewsUseCase(
     private val challengeRepository: ChallengeRepository
 ) {
-    suspend operator fun invoke() : List<ChallengePreview> {
-        return challengeRepository.getChallengingPreviews()
+    suspend operator fun invoke(uid: Int) : Result<List<ChallengePreview>> {
+        return challengeRepository.getChallengingPreviews(uid)
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetNewChallengePreviewsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetNewChallengePreviewsUseCase.kt
@@ -6,7 +6,7 @@ import com.whyranoid.domain.repository.ChallengeRepository
 class GetNewChallengePreviewsUseCase(
     private val challengeRepository: ChallengeRepository
 ) {
-    suspend operator fun invoke() : List<ChallengePreview> {
-        return challengeRepository.getNewChallengePreviews()
+    suspend operator fun invoke(uid: Int) : Result<List<ChallengePreview>> {
+        return challengeRepository.getNewChallengePreviews(uid)
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetTopRankChallengePreviewsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetTopRankChallengePreviewsUseCase.kt
@@ -1,0 +1,11 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.ChallengeRepository
+
+class GetTopRankChallengePreviewsUseCase(
+    private val challengeRepository: ChallengeRepository
+) {
+
+    suspend operator fun invoke() =
+        challengeRepository.getTopRankChallengePreviews()
+}

--- a/domain/src/main/java/com/whyranoid/domain/usecase/StartChallengeUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/StartChallengeUseCase.kt
@@ -1,0 +1,12 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.AccountRepository
+import com.whyranoid.domain.repository.ChallengeRepository
+
+class StartChallengeUseCase(
+    private val challengeRepository: ChallengeRepository,
+    private val accountRepository: AccountRepository
+) {
+    suspend operator fun invoke(challengeId: Int) =
+        challengeRepository.startChallenge(accountRepository.getUID().toInt(), challengeId)
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/component/ChallengeGoalContent.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/ChallengeGoalContent.kt
@@ -56,7 +56,7 @@ fun ChallengeGoalContent(
 
         val progressBarColor = challengeColor.progressBarColor
 
-        val progress = requireNotNull(challenge.process) / 100f
+        val progress = if (challenge.process == null) 0f else requireNotNull(challenge.process) / 100f
 
         Spacer(modifier = Modifier.height(30.dp))
 

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -120,7 +120,6 @@ fun ChallengeMainContent(
         LazyColumn(
             modifier = Modifier
                 .padding(paddingValues)
-//                .padding(horizontal = 20.dp)
         ) {
 
             item {

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -247,7 +247,7 @@ fun ChallengeMainContent(
                     horizontalArrangement = Arrangement.spacedBy(13.dp),
                     contentPadding = PaddingValues(20.dp)
                 ) {
-                    state.newChallengePreviewsState.getDataOrNull()?.let { newChallengePreviews ->
+                    state.topRankChallengePreviewState.getDataOrNull()?.let { newChallengePreviews ->
                         newChallengePreviews.chunkedList(3).forEach { list ->
                             item {
                                 Column() {

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeMainScreen.kt
@@ -182,27 +182,34 @@ fun ChallengeMainContent(
                     horizontalAlignment = Alignment.CenterHorizontally) {
 
                     state.challengingPreviewsState.getDataOrNull()?.let { challengingPreviews ->
-                        challengingPreviews.take(4).forEach {
-                            ChallengingItem(
-                                text = it.title,
-                                progress = it.progress!!,
-                                challengeColor = it.type.getColor(),
-                            ) {
-                                onChallengeItemClicked(it, true)
+
+                        if (challengingPreviews.isNotEmpty()) {
+                            challengingPreviews.take(4).forEach {
+                                ChallengingItem(
+                                    text = it.title,
+                                    progress = it.progress!!,
+                                    challengeColor = it.type.getColor(),
+                                ) {
+                                    onChallengeItemClicked(it, true)
+                                }
+                                Spacer(modifier = Modifier.height(10.dp))
                             }
-                            Spacer(modifier = Modifier.height(10.dp))
+
+                            IconButton(
+                                onClick = { onExpandButtonClicked() }) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ExpandMore,
+                                    modifier = Modifier
+                                        .width(20.dp)
+                                        .height(20.dp),
+                                    contentDescription = "도전중인 챌린지 더보기"
+                                )
+                            }
+                        } else {
+
                         }
 
-                        IconButton(
-                            onClick = { onExpandButtonClicked() }) {
-                            Icon(
-                                imageVector = Icons.Rounded.ExpandMore,
-                                modifier = Modifier
-                                    .width(20.dp)
-                                    .height(20.dp),
-                                contentDescription = "도전중인 챌린지 더보기"
-                            )
-                        }
+
                     } ?: run {
                         WalkieCircularProgressIndicator(Modifier.fillParentMaxWidth())
                     }

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeDetailViewModel.kt
@@ -1,18 +1,20 @@
 package com.whyranoid.presentation.viewmodel.challenge
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.whyranoid.domain.model.challenge.Challenge
 import com.whyranoid.domain.usecase.GetChallengeDetailUseCase
+import com.whyranoid.domain.usecase.StartChallengeUseCase
 import com.whyranoid.presentation.model.UiState
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
 sealed class ChallengeDetailSideEffect {
 
+    object StartChallengeSuccess : ChallengeDetailSideEffect()
+    object StartChallengeFailure : ChallengeDetailSideEffect()
 }
 
 data class ChallengeDetailState(
@@ -20,23 +22,30 @@ data class ChallengeDetailState(
 )
 
 class ChallengeDetailViewModel(
-    private val getChallengeDetailUseCase: GetChallengeDetailUseCase
+    private val getChallengeDetailUseCase: GetChallengeDetailUseCase,
+    private val startChallengeUseCase: StartChallengeUseCase
 ) : ViewModel(), ContainerHost<ChallengeDetailState, ChallengeDetailSideEffect> {
 
     override val container =
         container<ChallengeDetailState, ChallengeDetailSideEffect>(ChallengeDetailState())
 
-    fun getChallengeDetail(challengeId: Long) = intent{
+    fun getChallengeDetail(challengeId: Long) = intent {
+        reduce {
+            state.copy(challenge = UiState.Loading)
+        }
+        val challenge = getChallengeDetailUseCase(challengeId)
+        // TODO: Error Handling
+        reduce {
+            state.copy(challenge = UiState.Success(challenge))
+        }
+    }
 
-        viewModelScope.launch {
-            reduce {
-                state.copy(challenge = UiState.Loading)
-            }
-            val challenge = getChallengeDetailUseCase(challengeId)
-            // TODO: Error Handling
-            reduce {
-                state.copy(challenge = UiState.Success(challenge))
-            }
+    fun startChallenge(challengeId: Int) = intent {
+
+        startChallengeUseCase(challengeId).onSuccess {
+            postSideEffect(ChallengeDetailSideEffect.StartChallengeSuccess)
+        }.onFailure {
+            postSideEffect(ChallengeDetailSideEffect.StartChallengeFailure)
         }
 
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeMainViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeMainViewModel.kt
@@ -68,12 +68,16 @@ class ChallengeMainViewModel(
         reduce {
             state.copy(challengingPreviewsState = UiState.Loading)
         }
-        val challengingPreviews = getChallengingPreviewsUseCase()
-        reduce {
-            state.copy(
-                challengingPreviewsState = UiState.Success(challengingPreviews)
-            )
+        getChallengingPreviewsUseCase(state.uid.getDataOrNull() ?: 0).onSuccess { challengingPreviews ->
+            reduce {
+                state.copy(
+                    challengingPreviewsState = UiState.Success(challengingPreviews)
+                )
+            }
+        }.onFailure {
+
         }
+
     }
 
     private fun getTypedChallengeItems() = intent {

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeMainViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeMainViewModel.kt
@@ -7,6 +7,7 @@ import com.whyranoid.domain.usecase.GetChallengePreviewsByTypeUseCase
 import com.whyranoid.domain.usecase.GetChallengingPreviewsUseCase
 import com.whyranoid.domain.usecase.GetMyUidUseCase
 import com.whyranoid.domain.usecase.GetNewChallengePreviewsUseCase
+import com.whyranoid.domain.usecase.GetTopRankChallengePreviewsUseCase
 import com.whyranoid.presentation.model.UiState
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -22,12 +23,14 @@ data class ChallengeMainState(
     val newChallengePreviewsState: UiState<List<ChallengePreview>> = UiState.Idle,
     val challengingPreviewsState: UiState<List<ChallengePreview>> = UiState.Idle,
     val typedChallengePreviewsState: UiState<List<List<ChallengePreview>>> = UiState.Idle,
+    val topRankChallengePreviewState: UiState<List<ChallengePreview>> = UiState.Idle,
 )
 
 class ChallengeMainViewModel(
     private val getNewChallengePreviewsUseCase: GetNewChallengePreviewsUseCase,
     private val getChallengingPreviewsUseCase: GetChallengingPreviewsUseCase,
     private val getChallengePreviewsByTypeUseCase: GetChallengePreviewsByTypeUseCase,
+    private val getTopRankChallengePreviewsUseCase: GetTopRankChallengePreviewsUseCase,
     private val getMyUidUseCase: GetMyUidUseCase
 ) : ViewModel(), ContainerHost<ChallengeMainState, ChallengeMainSideEffect> {
 
@@ -45,6 +48,7 @@ class ChallengeMainViewModel(
         getNewChallengeItems()
         getChallengingItems()
         getTypedChallengeItems()
+        getTopRankChallengeItems()
     }
 
     private fun getNewChallengeItems() = intent {
@@ -52,7 +56,9 @@ class ChallengeMainViewModel(
             state.copy(newChallengePreviewsState = UiState.Loading)
         }
 
-        getNewChallengePreviewsUseCase(state.uid.getDataOrNull() ?: 0).onSuccess { newChallengePreviews ->
+        getNewChallengePreviewsUseCase(
+            state.uid.getDataOrNull() ?: 0
+        ).onSuccess { newChallengePreviews ->
             reduce {
                 state.copy(
                     newChallengePreviewsState = UiState.Success(newChallengePreviews)
@@ -68,7 +74,9 @@ class ChallengeMainViewModel(
         reduce {
             state.copy(challengingPreviewsState = UiState.Loading)
         }
-        getChallengingPreviewsUseCase(state.uid.getDataOrNull() ?: 0).onSuccess { challengingPreviews ->
+        getChallengingPreviewsUseCase(
+            state.uid.getDataOrNull() ?: 0
+        ).onSuccess { challengingPreviews ->
             reduce {
                 state.copy(
                     challengingPreviewsState = UiState.Success(challengingPreviews)
@@ -78,6 +86,21 @@ class ChallengeMainViewModel(
 
         }
 
+    }
+
+    private fun getTopRankChallengeItems() = intent {
+        reduce {
+            state.copy(typedChallengePreviewsState = UiState.Loading)
+        }
+        getTopRankChallengePreviewsUseCase().onSuccess { topRankChallengeItem ->
+            reduce {
+                state.copy(
+                    topRankChallengePreviewState = UiState.Success(topRankChallengeItem)
+                )
+            }
+        }.onFailure {
+
+        }
     }
 
     private fun getTypedChallengeItems() = intent {


### PR DESCRIPTION
## 😎 작업 내용
- 챌린지 관련 API 연결 및 기능 구현
 - 챌린지 메인 페이지
 - 챌린지 상세 페이지
 - 챌린지 도전하기 기능

## 🧐 변경된 내용
- 변경된 내용을 작성해주세요.

## 🥳 동작 화면
<img width="428" alt="Screenshot 2024-04-04 at 12 45 29 AM" src="https://github.com/Team-Walkie/Walkie/assets/90144041/7f7d9ddc-ed46-40e8-b194-247d5d200deb">

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 도전중인 챌린지가 없을 경우 보여줄 뷰가 필요함.