### PR TITLE
system status bar, system navigation bar 색상 변경, 가로모드 block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 
     implementation(libs.bundles.android.base)
 
-    val composeBom = platform("androidx.compose:compose-bom:2023.01.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
@@ -77,7 +77,7 @@ dependencies {
     implementation("androidx.compose.material3:material3-window-size-class")
 
     // Optional - Integration with activities
-    implementation("androidx.activity:activity-compose:1.7.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
     // Optional - Integration with ViewModels
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,10 +17,10 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat"
-        android:screenOrientation="portrait"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/whyranoid/walkie/MainActivity.kt
+++ b/app/src/main/java/com/whyranoid/walkie/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
 import com.whyranoid.presentation.screens.AppScreen
 import com.whyranoid.presentation.theme.WalkieTheme
@@ -13,6 +14,9 @@ class MainActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+
         setContent {
             WalkieTheme {
                 AppManageDialog()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 androidx-navigation = "2.5.3"
-androidx-core = "1.9.0"
+androidx-core = "1.13.1"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"
 naver-maps-android-sdk = "3.16.2"

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 
     implementation(libs.bundles.android.base)
 
-    val composeBom = platform("androidx.compose:compose-bom:2023.01.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
@@ -88,7 +88,7 @@ dependencies {
     implementation("androidx.compose.material3:material3-window-size-class")
 
     // Optional - Integration with activities
-    implementation("androidx.activity:activity-compose:1.7.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
     // Optional - Integration with ViewModels
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/AppScreen.kt
@@ -2,6 +2,7 @@ package com.whyranoid.presentation.screens
 
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
@@ -70,6 +71,7 @@ fun AppScreenContent(
     navController: NavHostController,
 ) {
     Scaffold(
+        modifier = Modifier.safeDrawingPadding(),
         bottomBar = {
             val navBackStackEntry by navController.currentBackStackEntryAsState()
             val currentDestination = navBackStackEntry?.destination

--- a/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
@@ -18,6 +18,8 @@ object SystemColor {
     val Error = Color(0xFFFF3257)
     val Positive = Color(0xFF414EF5)
     val Negative = Color(0xFF999999)
+    val StatusBar = Color.White
+    val SystemNavigationBar = Color.White
 }
 
 

--- a/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
@@ -18,8 +18,6 @@ object SystemColor {
     val Error = Color(0xFFFF3257)
     val Positive = Color(0xFF414EF5)
     val Negative = Color(0xFF999999)
-    val StatusBar = Color.White
-    val SystemNavigationBar = Color.White
 }
 
 

--- a/presentation/src/main/java/com/whyranoid/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/theme/Theme.kt
@@ -1,13 +1,19 @@
 package com.whyranoid.presentation.theme
 
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 // TODO: Dark Theme
 private val DarkColorScheme = darkColorScheme(
@@ -41,31 +47,24 @@ fun WalkieTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit,
 ) {
+    val view = LocalView.current
+    val statusBarColor by remember { mutableIntStateOf(Color.White.toArgb()) }
+    val systemNavigationBarColor by remember { mutableIntStateOf(Color.White.toArgb()) }
+
+    if (view.isInEditMode.not()) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = statusBarColor
+            window.navigationBarColor = systemNavigationBarColor
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
+            WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = true
+        }
+    }
 
     // TODO : Dynamic Color
     val colorScheme = when {
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
-    }
-
-    // Remember a SystemUiController
-    val systemUiController = rememberSystemUiController()
-
-    DisposableEffect(systemUiController, darkTheme) {
-
-        systemUiController.setSystemBarsColor(
-            color = Color.Transparent,
-            darkIcons = darkTheme.not()
-        )
-
-        systemUiController.setStatusBarColor(
-            color = colorScheme.surface,
-            darkIcons = darkTheme.not()
-        ) { requestedColor ->
-            requestedColor
-        }
-
-        onDispose {}
     }
 
     MaterialTheme(


### PR DESCRIPTION
## 😎 작업 내용
- system status bar, navigation bar 색상을 다크, 라이트 모드와 관계없이 색상 통일
- 가로모드 활성화 되어 있어서 가로모드 막음

## 🧐 변경된 내용
- compose에서 사용 가능한 edgeToEdge 함수를 사용하기 위해서 라이브러리 버전을 몇가지 올렸습니다! 혹시 사이드 이펙 생기면 말씀해주세요 (@yonghanJu @soopeach)

## 🥳 동작 화면
다크모드/라이트모드 동일하게 아래와 같이 작동

<img width="40%" src="https://github.com/Team-Walkie/Walkie/assets/39687846/c9ba22fb-ca39-4806-aec7-a7bafe1683cb">