### PR TITLE
마이페이지 하위 첼린지 페이지 구현, 뱃지 미리보기 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 26
         targetSdk = 33
         versionCode = 1
-        versionName = "1.0.10"
+        versionName = "1.0.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -113,7 +113,7 @@ val viewModelModule =
         single { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
         single { ChallengeDetailViewModel(get(), get()) }
         single { ChallengeExitViewModel(get()) }
-        factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
+        factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
         factory { RunningEditViewModel() }
         factory { SplashViewModel(get()) }

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -58,4 +58,12 @@ object API {
 
         const val MY = "/api/walkies/my"
     }
+
+    object BadgeAPI {
+        const val BADGES = "/api/badge/badges"
+
+        const val OBTAIN_BADGE = "/api/badge/obtain-badges"
+
+        const val UPDATE_BADGE_INDICES = "/api/badge/update-badge-indices"
+    }
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.data.datasource.challenge
 
+import android.util.Log
 import com.whyranoid.data.getResult
 import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
 import com.whyranoid.domain.datasource.ChallengeDataSource
@@ -52,9 +53,13 @@ class ChallengeDataSourceImpl(
             }
     }
 
-    // TODO: change to api call
     override suspend fun getUserBadges(uid: Long): Result<List<Badge>> {
-        return Result.success(Badge.DUMMY_LIST)
+        return runCatching {
+            challengeService.getBadgeList(uid)
+                .getResult { badgeList ->
+                    badgeList.map { it.toBadge() }
+                }
+        }
     }
 
     override suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit> {

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -2,6 +2,7 @@ package com.whyranoid.data.datasource.challenge
 
 import com.whyranoid.data.API
 import com.whyranoid.data.model.StatusWithMessage
+import com.whyranoid.data.model.challenge.BadgeResponse
 import com.whyranoid.data.model.challenge.ChallengeDetailResponse
 import com.whyranoid.data.model.challenge.ChallengePreviewResponse
 import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
@@ -40,4 +41,9 @@ interface ChallengeService {
     suspend fun startChallenge(
         @Body challengeStartRequest: ChallengeStartRequest
     ): Response<StatusWithMessage>
+
+    @GET(API.BadgeAPI.BADGES)
+    suspend fun getBadgeList(
+        @Query("walkieId") uid: Long
+    ): Response<List<BadgeResponse>>
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/component/badge/PlaceHolderBadge.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/badge/PlaceHolderBadge.kt
@@ -1,0 +1,49 @@
+package com.whyranoid.presentation.component.badge
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.whyranoid.presentation.theme.WalkieTheme
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import com.whyranoid.presentation.theme.WalkieColor
+
+@Composable
+fun PlaceholderBadge() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(WalkieColor.GrayDisable)
+    ) {
+        val pxValue = LocalDensity.current.run { 2.dp.toPx() }
+        Canvas(modifier = Modifier.size(48.dp)) {
+            drawCircle(
+                color = Color.Gray.copy(alpha = 0.3f),
+                style = Stroke(
+                    width = pxValue,
+                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
+                )
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun PlaceholderBadgePreview() {
+    WalkieTheme {
+        PlaceholderBadge()
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import coil.compose.AsyncImage
 import com.whyranoid.domain.util.EMPTY
 import com.whyranoid.presentation.component.badge.PlaceholderBadge
@@ -89,6 +90,7 @@ fun MyPageScreen(
         viewModel.getUserDetail(myUid, null)
         viewModel.getUserBadges(myUid)
         viewModel.getUserPostPreviews(myUid)
+        viewModel.getChallengingPreviews(myUid)
     }
 
     val state by viewModel.collectAsState()
@@ -126,6 +128,19 @@ fun MyPageScreen(
                 )
             }
         },
+        onChallengePreviewClicked = { challengeId: Long ->
+            val route = "challengeDetail/$challengeId/true"
+            navController.navigate(route)
+        },
+        goChallengeMainScreen = {
+            navController.navigate(Screen.ChallengeMainScreen.route) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
     )
 }
 
@@ -145,6 +160,8 @@ fun UserPageContent(
     onUnFollowButtonClicked: () -> Unit = {},
     onFollowerCountClicked: () -> Unit = {},
     onFollowingCountClicked: () -> Unit = {},
+    onChallengePreviewClicked: (challengeId: Long) -> Unit = {},
+    goChallengeMainScreen: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -376,9 +393,11 @@ fun UserPageContent(
                         }
                     }
 
-                    2 -> ChallengePage {
-
-                    }
+                    2 -> ChallengePage(
+                        state.challengingPreviewsState.getDataOrNull() ?: emptyList(),
+                        onChallengePreviewClicked,
+                        goChallengeMainScreen
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.whyranoid.domain.util.EMPTY
+import com.whyranoid.presentation.component.badge.PlaceholderBadge
 import com.whyranoid.presentation.component.bar.WalkieTopBar
 import com.whyranoid.presentation.reusable.TextWithCountSpaceBetween
 import com.whyranoid.presentation.screens.Screen
@@ -160,8 +161,7 @@ fun UserPageContent(
         Column(
             modifier = Modifier
                 .padding(paddingValues)
-                .padding(top = 28.dp)
-            ,
+                .padding(top = 28.dp),
         ) {
             state.userDetailState.getDataOrNull()?.let { userDetail ->
                 Row(
@@ -259,24 +259,49 @@ fun UserPageContent(
                 Spacer(Modifier.height(12.dp))
             }
 
-            state.userBadgesState.getDataOrNull()?.let { userBadges ->
-                LazyRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 20.dp),
-                ) {
-                    items(userBadges.size) { index ->
-                        AsyncImage(
-                            model = userBadges[index].imageUrl,
-                            contentDescription = "badge image",
-                            modifier = Modifier
-                                .padding(vertical = 8.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .size(56.dp),
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                    }
+            val badgeList = state.userBadgesState.getDataOrNull() ?: emptyList()
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(WalkieColor.GrayBackground)
+                    .padding(12.dp)
+            ) {
+                repeat(minOf(badgeList.size, 5)) {
+                    AsyncImage(
+                        model = badgeList[it].imageUrl,
+                        contentDescription = "badge image",
+                        modifier = Modifier
+                            .padding(vertical = 8.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .size(56.dp),
+                    )
                 }
+                repeat(5 - badgeList.size) { PlaceholderBadge() }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable(enabled = badgeList.size >= 5) {
+                        // TODO 전체 뱃지 페이지로 이동
+                    }
+                    .background(WalkieColor.GrayBackground)
+                    .padding(vertical = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "전체 뱃지 보기" + if (badgeList.size < 5) "(${badgeList.size}/5)" else "",
+                    fontSize = 14.sp,
+                    color = if (badgeList.size < 5) WalkieColor.GrayBorder else Color.Black
+                )
             }
 
             Spacer(Modifier.height(12.dp))

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -144,11 +144,16 @@ fun MyPageScreen(
     )
 }
 
+/**
+ * User page content
+ *
+ * @param nickname 상대방 페이지인 경우에 존재, 마이페이지일 경우 null
+ */
 @SuppressLint("CoroutineCreationDuringComposition")
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun UserPageContent(
-    nickname: String? = null,
+    nickname: String? = null, // 상대방 페이지인 경우에 존재, 마이페이지일 경우 null
     state: UserPageState,
     onPostPreviewClicked: (id: Long) -> Unit = {},
     onPostCreateClicked: () -> Unit = {},
@@ -300,25 +305,29 @@ fun UserPageContent(
                 }
                 repeat(5 - badgeList.size) { PlaceholderBadge() }
             }
-            Spacer(modifier = Modifier.height(12.dp))
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .clickable(enabled = badgeList.size >= 5) {
-                        // TODO 전체 뱃지 페이지로 이동
-                    }
-                    .background(WalkieColor.GrayBackground)
-                    .padding(vertical = 8.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = "전체 뱃지 보기" + if (badgeList.size < 5) "(${badgeList.size}/5)" else "",
-                    fontSize = 14.sp,
-                    color = if (badgeList.size < 5) WalkieColor.GrayBorder else Color.Black
-                )
+            // 마이페이지인 경우
+            if (nickname == null) {
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(enabled = badgeList.size >= 5) {
+                            // TODO 전체 뱃지 페이지로 이동
+                        }
+                        .background(WalkieColor.GrayBackground)
+                        .padding(vertical = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "전체 뱃지 보기" + if (badgeList.size < 5) "(${badgeList.size}/5)" else "",
+                        fontSize = 14.sp,
+                        color = if (badgeList.size < 5) WalkieColor.GrayBorder else Color.Black
+                    )
+                }
             }
 
             Spacer(Modifier.height(12.dp))

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/UserPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/UserPageScreen.kt
@@ -23,6 +23,7 @@ fun UserPageScreen(
         viewModel.getUserDetail(uid, isFollowing)
         viewModel.getUserBadges(uid)
         viewModel.getUserPostPreviews(uid)
+        viewModel.getChallengingPreviews(uid)
     }
 
     val state by viewModel.collectAsState()

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
@@ -1,11 +1,11 @@
 package com.whyranoid.presentation.screens.mypage.tabs
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
@@ -14,11 +14,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.whyranoid.domain.model.challenge.ChallengePreview
+import com.whyranoid.presentation.component.ChallengeItem
 import com.whyranoid.presentation.component.button.WalkiePositiveButton
+import com.whyranoid.presentation.theme.ChallengeColor.getColor
 import com.whyranoid.presentation.theme.WalkieTypography
 
 @Composable
 fun ChallengePage(
+    challengePreviews: List<ChallengePreview>,
+    onChallengePreviewClicked: (challengeId: Long) -> Unit,
     onGotoChallengeClicked: () -> Unit
 ) {
 
@@ -29,19 +34,33 @@ fun ChallengePage(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
-        Column {
-            Spacer(modifier = Modifier.height(30.dp))
-            Text(
-                text = "챌린지에 도전하고 프로필에 뱃지를 채워보세요!",
-                style = WalkieTypography.Body1_Normal.copy(color = Color.Black.copy(alpha = 0.5f))
-            )
-        }
+        if (challengePreviews.isEmpty()) {
 
-        Box(modifier = Modifier.padding(20.dp)) {
-            WalkiePositiveButton(text = "도전하러 가기") {
-                onGotoChallengeClicked()
+            Column {
+                Spacer(modifier = Modifier.height(30.dp))
+                Text(
+                    text = "챌린지에 도전하고 프로필에 뱃지를 채워보세요!",
+                    style = WalkieTypography.Body1_Normal.copy(color = Color.Black.copy(alpha = 0.5f))
+                )
+            }
+
+            Box(modifier = Modifier.padding(20.dp)) {
+                WalkiePositiveButton(text = "도전하러 가기") {
+                    onGotoChallengeClicked()
+                }
+            }
+        } else {
+            Column(Modifier.fillMaxWidth()) {
+                challengePreviews.forEach {
+                    ChallengeItem(
+                        Modifier.padding(horizontal = 20.dp),
+                        it.type.getColor(),
+                        text = it.title
+                    ) {
+                        onChallengePreviewClicked(it.id)
+                    }
+                }
             }
         }
-
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/theme/Color.kt
@@ -8,6 +8,7 @@ object WalkieColor {
     val Primary = Color(0xFFFB8947)
     val Secondary = Color(0xFFE75300)
     val Tertiary = Color(0xFFFAC03A)
+    val GrayBackground = Color(0xFFF8F8F8)
     val GrayDisable = Color(0xFFECECEC)
     val GrayDefault = Color(0xFFD9D9D9)
     val GrayBorder = Color(0xFFB9BBB8)


### PR DESCRIPTION
## 😎 작업 내용
- 마이페이지 하위 첼린지 페이지 기능 구현
- 뱃지 미리보기 화면 구현

## 🥳 동작 화면
<img src="https://github.com/Team-Walkie/Walkie/assets/65655825/6fb5c897-7c8e-466e-ba62-1668be754cca" width="350">

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음