### PR TITLE
챌린지 그만두기 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,4 +125,12 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
+
+    // orbit
+    // TODO: change To Core For Compose Multiplatform
+    val orbitVersion = "4.6.1"
+    implementation("org.orbit-mvi:orbit-viewmodel:$orbitVersion")
+    implementation("org.orbit-mvi:orbit-compose:$orbitVersion")
+    // Tests
+    testImplementation("org.orbit-mvi:orbit-test:$orbitVersion")
 }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -113,9 +113,9 @@ import java.util.concurrent.TimeUnit
 
 val viewModelModule =
     module {
-        single { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
-        single { ChallengeDetailViewModel(get(), get()) }
-        single { ChallengeExitViewModel(get(), get()) }
+        factory { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
+        factory { ChallengeDetailViewModel(get(), get()) }
+        factory { ChallengeExitViewModel(get(), get()) }
         factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
         factory { RunningEditViewModel() }

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -49,6 +49,7 @@ import com.whyranoid.domain.repository.PostRepository
 import com.whyranoid.domain.repository.RunningHistoryRepository
 import com.whyranoid.domain.repository.RunningRepository
 import com.whyranoid.domain.repository.UserRepository
+import com.whyranoid.domain.usecase.ChangeChallengeStatusUseCase
 import com.whyranoid.domain.usecase.GetChallengeDetailUseCase
 import com.whyranoid.domain.usecase.GetChallengePreviewsByTypeUseCase
 import com.whyranoid.domain.usecase.GetChallengingPreviewsUseCase
@@ -114,7 +115,7 @@ val viewModelModule =
     module {
         single { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
         single { ChallengeDetailViewModel(get(), get()) }
-        single { ChallengeExitViewModel(get()) }
+        single { ChallengeExitViewModel(get(), get()) }
         factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
         factory { RunningEditViewModel() }
@@ -193,6 +194,7 @@ val useCaseModule =
         single { GetMyFollowingUseCase(get(), get()) }
         single { SendCommentUseCase(get(), get()) }
         single { GetUserUseCase(get()) }
+        single { ChangeChallengeStatusUseCase(get(), get())}
     }
 
 val databaseModule =

--- a/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
+++ b/app/src/main/java/com/whyranoid/walkie/KoinModules.kt
@@ -106,6 +106,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -113,22 +114,22 @@ import java.util.concurrent.TimeUnit
 
 val viewModelModule =
     module {
-        factory { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
-        factory { ChallengeDetailViewModel(get(), get()) }
-        factory { ChallengeExitViewModel(get(), get()) }
-        factory { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-        factory { RunningViewModel(get(), get(), get(), get(), get(), get()) }
-        factory { RunningEditViewModel() }
-        factory { SplashViewModel(get()) }
-        factory { SignInViewModel(get()) }
-        factory { SelectHistoryViewModel(get()) }
-        factory { EditProfileViewModel(get()) }
-        factory { AddPostViewModel(get()) }
-        factory { SearchFriendViewModel(get(), get(), get()) }
-        factory { DialogViewModel(get(), get(), get(), get(), get(), get()) }
-        factory { CommunityScreenViewModel(get(), get(), get()) }
-        factory { FollowingViewModel(get(), get(), get(), get(), get(), get()) }
-        factory { SettingViewModel(get(), get()) }
+        viewModel { ChallengeMainViewModel(get(), get(), get(), get(), get()) }
+        viewModel { ChallengeDetailViewModel(get(), get()) }
+        viewModel { ChallengeExitViewModel(get(), get()) }
+        viewModel { UserPageViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+        viewModel { RunningViewModel(get(), get(), get(), get(), get(), get()) }
+        viewModel { RunningEditViewModel() }
+        viewModel { SplashViewModel(get()) }
+        viewModel { SignInViewModel(get()) }
+        viewModel { SelectHistoryViewModel(get()) }
+        viewModel { EditProfileViewModel(get()) }
+        viewModel { AddPostViewModel(get()) }
+        viewModel { SearchFriendViewModel(get(), get(), get()) }
+        viewModel { DialogViewModel(get(), get(), get(), get(), get(), get()) }
+        viewModel { CommunityScreenViewModel(get(), get(), get()) }
+        viewModel { FollowingViewModel(get(), get(), get(), get(), get(), get()) }
+        viewModel { SettingViewModel(get(), get()) }
     }
 
 val repositoryModule =

--- a/data/src/main/java/com/whyranoid/data/API.kt
+++ b/data/src/main/java/com/whyranoid/data/API.kt
@@ -45,6 +45,8 @@ object API {
 
     const val CHALLENGE_START = "api/challenge/challenge-detail/start"
 
+    const val CHALLENGE_CHANGE_STATUS = "api/challenge/challenge-detail/update-status"
+
     object WalkingControl {
         const val RUNNING_START = "api/walk/start"
 

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.whyranoid.data.datasource.challenge
 
-import android.util.Log
 import com.whyranoid.data.getResult
+import com.whyranoid.data.model.challenge.request.ChallengeChangeStatusRequest
 import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
 import com.whyranoid.domain.datasource.ChallengeDataSource
 import com.whyranoid.domain.model.challenge.Badge
@@ -69,6 +69,12 @@ class ChallengeDataSourceImpl(
     override suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit> {
         return runCatching {
             challengeService.startChallenge(ChallengeStartRequest(uid, challengeId))
+        }
+    }
+
+    override suspend fun changeChallengeStatus(challengeId: Int, status: String, walkieId: Int): Result<Unit> {
+        return runCatching {
+            challengeService.changeChallengeStatus(ChallengeChangeStatusRequest(challengeId, status, walkieId))
         }
     }
 }

--- a/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
+++ b/data/src/main/java/com/whyranoid/data/datasource/challenge/ChallengeService.kt
@@ -5,6 +5,7 @@ import com.whyranoid.data.model.StatusWithMessage
 import com.whyranoid.data.model.challenge.BadgeResponse
 import com.whyranoid.data.model.challenge.ChallengeDetailResponse
 import com.whyranoid.data.model.challenge.ChallengePreviewResponse
+import com.whyranoid.data.model.challenge.request.ChallengeChangeStatusRequest
 import com.whyranoid.data.model.challenge.request.ChallengeStartRequest
 import retrofit2.Response
 import retrofit2.http.Body
@@ -46,4 +47,9 @@ interface ChallengeService {
     suspend fun getBadgeList(
         @Query("walkieId") uid: Long
     ): Response<List<BadgeResponse>>
+
+    @POST(API.CHALLENGE_CHANGE_STATUS)
+    suspend fun changeChallengeStatus(
+        @Body changeChallengeStatusRequest: ChallengeChangeStatusRequest
+    ) : Response<StatusWithMessage>
 }

--- a/data/src/main/java/com/whyranoid/data/model/challenge/request/ChallengeChangeStatusRequest.kt
+++ b/data/src/main/java/com/whyranoid/data/model/challenge/request/ChallengeChangeStatusRequest.kt
@@ -1,0 +1,7 @@
+package com.whyranoid.data.model.challenge.request
+
+data class ChallengeChangeStatusRequest(
+    val challengeId: Int,
+    val status: String,
+    val walkieId: Int
+)

--- a/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/repository/ChallengeRepositoryImpl.kt
@@ -37,4 +37,8 @@ class ChallengeRepositoryImpl(
     override suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit> {
         return challengeDataSource.startChallenge(uid, challengeId)
     }
+
+    override suspend fun changeChallengeStatus(challengeId: Int, status: String, walkieId: Int): Result<Unit> {
+        return challengeDataSource.changeChallengeStatus(challengeId, status, walkieId)
+    }
 }

--- a/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
+++ b/domain/src/main/java/com/whyranoid/domain/datasource/ChallengeDataSource.kt
@@ -20,4 +20,6 @@ interface ChallengeDataSource {
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
 
     suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit>
+
+    suspend fun changeChallengeStatus(challengeId: Int, status: String, walkieId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/ChallengeRepository.kt
@@ -20,4 +20,6 @@ interface ChallengeRepository {
     suspend fun getUserBadges(uid: Long): Result<List<Badge>>
 
     suspend fun startChallenge(uid: Int, challengeId: Int): Result<Unit>
+
+    suspend fun changeChallengeStatus(challengeId: Int, status: String, walkieId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/ChangeChallengeStatusUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/ChangeChallengeStatusUseCase.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.ChallengeRepository
+import javax.inject.Inject
+
+class ChangeChallengeStatusUseCase @Inject constructor(
+    private val challengeRepository: ChallengeRepository,
+    private val getMyUidUseCase: GetMyUidUseCase
+) {
+    suspend operator fun invoke(challengeId: Int, status: String): Result<Unit> {
+        val myId = getMyUidUseCase()
+        return challengeRepository.changeChallengeStatus(challengeId, status, myId.getOrNull()?.toInt() ?: -1)
+    }
+
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeExitScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeExitScreen.kt
@@ -29,10 +29,12 @@ import com.whyranoid.presentation.component.button.WalkieNegativeButton
 import com.whyranoid.presentation.component.button.WalkiePositiveButton
 import com.whyranoid.presentation.reusable.WalkieCircularProgressIndicator
 import com.whyranoid.presentation.theme.WalkieTypography
+import com.whyranoid.presentation.viewmodel.challenge.ChallengeExitSideEffect
 import com.whyranoid.presentation.viewmodel.challenge.ChallengeExitState
 import com.whyranoid.presentation.viewmodel.challenge.ChallengeExitViewModel
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun ChallengeExitScreen(
@@ -40,6 +42,7 @@ fun ChallengeExitScreen(
     challengeId: Long,
 ) {
 
+    val context = LocalContext.current
     val viewModel = koinViewModel<ChallengeExitViewModel>()
 
     LaunchedEffect(true) {
@@ -48,10 +51,23 @@ fun ChallengeExitScreen(
 
     val state by viewModel.collectAsState()
 
+    viewModel.collectSideEffect {
+        when (it) {
+            ChallengeExitSideEffect.StopChallengeSuccess -> {
+                Toast.makeText(context, "챌린지를 성공적으로 중단하였습니다.", Toast.LENGTH_SHORT).show()
+                navController.popBackStack()
+            }
+
+            ChallengeExitSideEffect.StopChallengeFailure -> {
+                Toast.makeText(context, "챌린지 중단에 실패하였습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     ChallengeExitContent(
         state,
         onPositiveButtonClicked = {
-            // TODO
+            viewModel.stopChallenge()
         },
         onNegativeButtonClicked = {
             navController.popBackStack()
@@ -135,7 +151,6 @@ fun ChallengeExitContent(
                 ) {
                     WalkiePositiveButton(text = "확인") {
                         onPositiveButtonClicked()
-                        Toast.makeText(context, "확인", Toast.LENGTH_SHORT).show()
                     }
                 }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeExitViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/viewmodel/challenge/ChallengeExitViewModel.kt
@@ -2,15 +2,18 @@ package com.whyranoid.presentation.viewmodel.challenge
 
 import androidx.lifecycle.ViewModel
 import com.whyranoid.domain.model.challenge.Challenge
+import com.whyranoid.domain.usecase.ChangeChallengeStatusUseCase
 import com.whyranoid.domain.usecase.GetChallengeDetailUseCase
 import com.whyranoid.presentation.model.UiState
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
 sealed class ChallengeExitSideEffect {
-
+    object StopChallengeSuccess : ChallengeExitSideEffect()
+    object StopChallengeFailure : ChallengeExitSideEffect()
 }
 
 data class ChallengeExitState(
@@ -19,6 +22,7 @@ data class ChallengeExitState(
 
 class ChallengeExitViewModel(
     private val getChallengeDetailUseCase: GetChallengeDetailUseCase,
+    private val changeChallengeStatusUseCase: ChangeChallengeStatusUseCase
 ) : ViewModel(),
     ContainerHost<ChallengeExitState, ChallengeExitSideEffect> {
 
@@ -32,6 +36,17 @@ class ChallengeExitViewModel(
         val challenge = getChallengeDetailUseCase(challengeId)
         reduce {
             state.copy(challenge = UiState.Success(challenge))
+        }
+    }
+
+    fun stopChallenge() = intent {
+        changeChallengeStatusUseCase(
+            state.challenge.getDataOrNull()?.id?.toInt() ?: 0,
+            "N",
+        ).onSuccess {
+            postSideEffect(ChallengeExitSideEffect.StopChallengeSuccess)
+        }.onFailure {
+            postSideEffect(ChallengeExitSideEffect.StopChallengeFailure)
         }
     }
 


### PR DESCRIPTION
## 😎 작업 내용
- 챌린지 그만두기 기능 구현

## 🧐 변경된 내용
- 변경된 내용을 작성해주세요.

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- ~Orbit의 이슈인지는 모르겠는데, 챌린지 디테일 화면을 처음 들어가면, 다른 챌린지를 들어가도 무조건 해당 챌린지의 정보로 ChallengeDetail 스크린이 반영됨~
- ~로그를 찍어보니 LaunchedEffect 내의 뷰모델 함수를 호출하는 부분은 동작하는데, 뷰모델에 있는 함수 자체가 동작을 안함.~
- koin에서 의존성 주입하는 방식의 라이프 사이클 문제였음