### PR TITLE
이미지 저장 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,11 +32,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     buildFeatures {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "7.4.2" apply false
-    id("com.android.library") version "7.4.2" apply false
+    id("com.android.application") version "8.2.0" apply false
+    id("com.android.library") version "8.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.0" apply false
     id("org.jetbrains.kotlin.jvm") version "1.8.0" apply false
     id("com.google.gms.google-services") version "4.3.15" apply false

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -37,11 +37,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 14 10:19:07 KST 2023
+#Thu Feb 13 22:05:41 KST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -37,11 +37,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     buildFeatures {
@@ -59,7 +59,7 @@ dependencies {
     implementation(libs.bundles.android.base)
     implementation(libs.play.services.oss.licenses)
 
-    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    val composeBom = platform("androidx.compose:compose-bom:2025.01.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
 

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -3,7 +3,10 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 
     <application>

--- a/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
@@ -38,7 +38,7 @@ fun ChallengeExitModalBottomSheetContainer(
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
     modalSheetState: ModalBottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
-        confirmStateChange = { it != ModalBottomSheetValue.HalfExpanded },
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
         skipHalfExpanded = true
     ),
     onPositiveButtonClicked: (Challenge) -> Unit = {},

--- a/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/component/bottomsheet/ChallengeExitModalBottomSheetContainer.kt
@@ -74,7 +74,7 @@ fun ChallengeExitModalBottomSheetContainer(
                 Spacer(modifier = Modifier.height(31.dp))
 
                 AsyncImage(
-                    model = challenge.badge.imageUrl, contentDescription = "",
+                    model = challenge.badge.failureImageUrl, contentDescription = "",
                     modifier = Modifier
                         .size(100.dp)
                         .padding(bottom = 10.dp),

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
@@ -275,12 +275,6 @@ fun ChallengeDetailContent(
                                 )
                                 Spacer(modifier = Modifier.height(40.dp))
 
-
-                                // Todo: remove
-                                WalkiePositiveButton(text = "완료하기") {
-                                    onChallengeCompleteButtonClicked(challenge.id)
-                                }
-
                             }
                         } else {
                             Spacer(modifier = Modifier.height(28.dp))

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeDetailScreen.kt
@@ -118,7 +118,7 @@ fun ChallengeDetailContent(
     val coroutineScope = rememberCoroutineScope()
     val modalSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
-        confirmStateChange = { it != ModalBottomSheetValue.HalfExpanded },
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
         skipHalfExpanded = true
     )
 

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeExitScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeExitScreen.kt
@@ -110,7 +110,7 @@ fun ChallengeExitContent(
                 Spacer(modifier = Modifier.height(57.dp))
 
                 AsyncImage(
-                    model = challenge.badge.imageUrl, contentDescription = "",
+                    model = challenge.badge.failureImageUrl, contentDescription = "",
                     modifier = Modifier
                         .size(208.dp)
                         .clip(CircleShape),

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeImageSaveScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/challenge/ChallengeImageSaveScreen.kt
@@ -1,22 +1,38 @@
 package com.whyranoid.presentation.screens.challenge
 
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -27,8 +43,12 @@ import com.whyranoid.presentation.R
 import com.whyranoid.presentation.component.bar.BasicBackButtonTopBar
 import com.whyranoid.presentation.theme.WalkieTypography
 import com.whyranoid.presentation.viewmodel.challenge.ChallengeImageSaveViewModel
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 
 @Composable
 fun ChallengeImageSaveScreen(
@@ -38,10 +58,13 @@ fun ChallengeImageSaveScreen(
 
     val viewModel = koinViewModel<ChallengeImageSaveViewModel>()
     val state by viewModel.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val graphicsLayer = rememberGraphicsLayer()
 
     LaunchedEffect(Unit) {
         viewModel.getChallengeDetail(challengeId)
     }
+
     Scaffold(
         topBar = {
             BasicBackButtonTopBar {
@@ -62,14 +85,30 @@ fun ChallengeImageSaveScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 Box(
-                    modifier = Modifier,
-                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(20.dp))
+                        .drawWithContent {
+                            graphicsLayer.record {
+                                this@drawWithContent.drawContent()
+                            }
+                            drawLayer(graphicsLayer)
+                        }
+                        .clickable {
+                            coroutineScope.launch {
+                                val bitmap = graphicsLayer.toImageBitmap()
+                                saveBitmapToGallery(
+                                    context = navController.context,
+                                    bitmap = bitmap.asAndroidBitmap(),
+                                    fileName = "walkie_challenge_${challengeId}"
+                                )
+                            }
+                        },
+                    contentAlignment = Alignment.TopCenter,
                 ) {
 
                     Image(
                         modifier = Modifier
-                            .size(300.dp)
-                            .padding(20.dp),
+                            .size(300.dp),
                         painter = painterResource(id = R.drawable.bg_badge),
                         contentDescription = "Badge background"
                     )
@@ -78,17 +117,22 @@ fun ChallengeImageSaveScreen(
                         modifier = Modifier,
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        AsyncImage(
-                            model = state.challenge.getDataOrNull()?.badge?.imageUrl,
-                            contentDescription = "challenge badge image"
-                        )
 
-                        Spacer(modifier = Modifier.size(13.dp))
+                        Spacer(modifier = Modifier.height(25.dp))
 
                         Text(
                             text = state.challenge.getDataOrNull()?.name ?: String.EMPTY,
                             style = WalkieTypography.Title
                         )
+
+                        Spacer(modifier = Modifier.height(6.dp))
+
+                        AsyncImage(
+                            model = state.challenge.getDataOrNull()?.badge?.imageUrl,
+                            modifier = Modifier.size(180.dp),
+                            contentDescription = "challenge badge image"
+                        )
+
                     }
 
                     Box(
@@ -97,7 +141,7 @@ fun ChallengeImageSaveScreen(
                     ) {
                         Text(
                             modifier = Modifier
-                                .padding(end = 30.dp, bottom = 30.dp),
+                                .padding(end = 22.dp, bottom = 20.dp),
                             text = getToday().split(" ").first().replace("-", "."),
                             style = WalkieTypography.Body2
                         )
@@ -105,6 +149,48 @@ fun ChallengeImageSaveScreen(
 
                 }
             }
+        }
+    }
+}
+
+
+fun saveBitmapToGallery(context: Context, bitmap: Bitmap, fileName: String) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        // Android 10(Q) 이상 - Scoped Storage 방식
+        val contentValues = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "$fileName.jpg")
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+
+        val contentResolver = context.contentResolver
+        val uri =
+            contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+
+        uri?.let {
+            try {
+                contentResolver.openOutputStream(it)?.use { outputStream ->
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+                }
+                contentValues.clear()
+                contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+                contentResolver.update(uri, contentValues, null, null)
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
+    } else {
+        val directory =
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+        val file = File(directory, "$fileName.jpg")
+
+        try {
+            FileOutputStream(file).use { outputStream ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
         }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/MyPageScreen.kt
@@ -496,7 +496,7 @@ fun MyPageTopAppBar(
                 Icon(Icons.Default.Menu, "")
             }
         },
-        colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.White),
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
     )
 }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
@@ -54,6 +54,9 @@ fun ChallengePage(
             }
         } else {
             Column(Modifier.fillMaxWidth()) {
+
+                Spacer(modifier = Modifier.height(16.dp))
+
                 challengePreviews.forEach {
                     ChallengeItem(
                         Modifier.padding(horizontal = 20.dp),

--- a/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/screens/mypage/tabs/ChallengePage.kt
@@ -62,6 +62,8 @@ fun ChallengePage(
                     ) {
                         onChallengePreviewClicked(it.id)
                     }
+
+                    Spacer(modifier = Modifier.height(10.dp))
                 }
             }
         }


### PR DESCRIPTION
## 😎 작업 내용
- 이미지 저장 기능 구현

## 🧐 변경된 내용
- 🚨그레들 버전 8.4.0 으로 업데이트🚨
- 🚨컴포즈 붐 2025.01.00 버전으로 업데이트🚨
  - 위의 업데이트 사항은, 이미지 저장 modifier를 사용하기 위함
  - 혹시 문제가 생긴다면 다운그래이드!
  - 컴포즈 버전 업데이트에 따른 수정사항(파라미터 이름 등)은 반영
  - 앱이 정상적으로 구동되는 것 확인

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 현재는 뱃지 이미지를 클릭하면 저장됨
- 완료 후 별도의 메시지가 아직 없음.
- 저장하는 버튼이 필요